### PR TITLE
Fixed performance issue in admin panel for trainee foreignKeys

### DIFF
--- a/ap/accounts/admin.py
+++ b/ap/accounts/admin.py
@@ -7,6 +7,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from .models import User, Trainee, TrainingAssistant
 from aputils.admin import VehicleInline, EmergencyInfoInline
+from django_extensions.admin import ForeignKeyAutocompleteAdmin
 
 """" ACCOUNTS admin.py """
 
@@ -181,7 +182,16 @@ class FirstTermMentorListFilter(SimpleListFilter):
 			return q
 
 
-class TraineeAdmin(admin.ModelAdmin):
+class TraineeAdmin(ForeignKeyAutocompleteAdmin):
+
+    # User is your FK attribute in your model
+    # first_name and email are attributes to search for in the FK model
+    related_search_fields = {
+       'TA': ('account__firstname', 'account__lastname', 'account__email'),
+       'mentor': ('account__firstname', 'account__lastname', 'account__email'),
+       'spouse': ('account__firstname', 'account__lastname', 'account__email'),
+    }
+
     fieldsets = (
         (None, {
             'fields': (('account', 'active',), 'type', 'locality', 'term',

--- a/ap/ap/settings/base.py
+++ b/ap/ap/settings/base.py
@@ -138,6 +138,7 @@ INSTALLED_APPS = (
     # admin third-party modules
     'adminactions',
     'suit',  # needs to be in front of 'django.contrib.admin'
+    'django_extensions',
 
     # django contrib
     'django.contrib.auth',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,6 +9,7 @@ django-bootstrap3-datetimepicker==2.2.3
 django-select2==4.2.2
 djangorestframework==2.3.14
 django-sql-explorer==0.6
+django-extensions>=0.5.0
 
 # database extensions
 djorm-ext-core==0.7

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,12 +9,11 @@ pudb==2014.1
 # testing
 coverage==3.6
 mock==1.0.1
-django-autofixture==0.8.0
+django-autofixture>=0.8.0
 python-coveralls
 django-discover-runner==1.0
 django-nose==1.2
 
 # developer tools
-django-extensions==1.3.8
 django-debug-toolbar==1.2.1
 django-reset==0.2.0


### PR DESCRIPTION
Issue #128 - Fixed performance issue in admin panel for trainee foreignKeys TA, spouse, and mentor by adding autocomplete box to replace old drop down menu.

Also fixed Issue #126 by adding search box on top of trainee list.