### PR TITLE
Event Group Create

### DIFF
--- a/ap/schedules/forms.py
+++ b/ap/schedules/forms.py
@@ -42,6 +42,7 @@ class EventGroupForm(forms.ModelForm):
         fields = ('type', 'name', 'code', 'description', 'classs', 'monitor', 'term', 'start', 'end')
         help_texts = {
             'start': 'Set the date to the first occurrence of the event',
+            'end': 'Set the date to the first occurrence of the event',
         }
         widgets = { 'start': DateTimePicker(options={'format': 'MM/DD/YYYY HH:mm'}),
                     'end': DateTimePicker(options={'format': 'MM/DD/YYYY HH:mm'}) }

--- a/ap/schedules/forms.py
+++ b/ap/schedules/forms.py
@@ -10,11 +10,39 @@ from localities.models import Locality
 
 
 class EventForm(forms.ModelForm):
-    trainees = ModelSelect2MultipleField(queryset=Trainee.objects, required=False, search_fields=['^first_name', '^last_name'])
+    active_trainees = Trainee.objects.filter(active=True)
+    trainees = ModelSelect2MultipleField(queryset=active_trainees, required=False, search_fields=['^first_name', '^last_name'])
 
     class Meta:
         model = Event
         fields = ('type', 'name', 'code', 'description', 'classs', 'monitor', 'term', 'start', 'end')
+        widgets = { 'start': DateTimePicker(options={'format': 'MM/DD/YYYY HH:mm'}),
+                    'end': DateTimePicker(options={'format': 'MM/DD/YYYY HH:mm'}) }
+
+
+class EventGroupForm(forms.ModelForm):
+
+    DAYS = (
+        ('0', "Lord's Day"),
+        ('1', 'Monday'),
+        ('2', 'Tuesday'),
+        ('3', 'Wednesday'),
+        ('4', 'Thursday'),
+        ('5', 'Friday'), 
+        ('6', 'Saturday'),
+    )
+
+    repeat = forms.MultipleChoiceField(choices=DAYS, help_text="Which days this event repeats on")
+    duration = forms.IntegerField(help_text="How many weeks this event repeats for")
+    active_trainees = Trainee.objects.filter(active=True)
+    trainees = ModelSelect2MultipleField(queryset=active_trainees, required=False, search_fields=['^first_name', '^last_name']) 
+
+    class Meta:
+        model = Event
+        fields = ('type', 'name', 'code', 'description', 'classs', 'monitor', 'term', 'start', 'end')
+        help_texts = {
+            'start': 'Set the date to the first occurrence of the event',
+        }
         widgets = { 'start': DateTimePicker(options={'format': 'MM/DD/YYYY HH:mm'}),
                     'end': DateTimePicker(options={'format': 'MM/DD/YYYY HH:mm'}) }
 

--- a/ap/schedules/forms.py
+++ b/ap/schedules/forms.py
@@ -23,13 +23,13 @@ class EventForm(forms.ModelForm):
 class EventGroupForm(forms.ModelForm):
 
     DAYS = (
-        ('0', "Lord's Day"),
-        ('1', 'Monday'),
-        ('2', 'Tuesday'),
-        ('3', 'Wednesday'),
-        ('4', 'Thursday'),
-        ('5', 'Friday'), 
-        ('6', 'Saturday'),
+        ('0', 'Monday'),
+        ('1', 'Tuesday'),
+        ('2', 'Wednesday'),
+        ('3', 'Thursday'),
+        ('4', 'Friday'), 
+        ('5', 'Saturday'),
+        ('6', "Lord's Day"),
     )
 
     repeat = forms.MultipleChoiceField(choices=DAYS, help_text="Which days this event repeats on")

--- a/ap/schedules/models.py
+++ b/ap/schedules/models.py
@@ -92,11 +92,15 @@ class EventGroup(models.Model):
 
     # which days this event repeats, starting with Monday (0) through LD (6)
     # i.e. an event that repeats on Tuesday and Thursday would be (1,3)
-    repeat = models.CommaSeparatedIntegerField(max_length=7)
+    repeat = models.CommaSeparatedIntegerField(max_length=20)
     duration = models.PositiveSmallIntegerField()  # how many weeks this event repeats
 
-    # override delete(): ensure all events in eventgroup are also deleted
+    def create_children(self, Event):
+        # create repeating child Events
+        pass
+
     def delete(self, *args, **kwargs):
+        # override delete(): ensure all events in eventgroup are also deleted
         Event.objects.filter(eventgroup=self.id).delete()
         super(EventGroup, self).delete(*args, **kwargs)
 

--- a/ap/schedules/models.py
+++ b/ap/schedules/models.py
@@ -90,12 +90,10 @@ class Event(models.Model):
 
 class EventGroup(models.Model):
 
-    # for now, this should just be the same as the event name
-    name = models.CharField(max_length=30)
-
     # which days this event repeats, starting with Monday (0) through LD (6)
     # i.e. an event that repeats on Tuesday and Thursday would be (1,3)
     repeat = models.CommaSeparatedIntegerField(max_length=7)
+    duration = models.PositiveSmallIntegerField()  # how many weeks this event repeats
 
     # override delete(): ensure all events in eventgroup are also deleted
     def delete(self, *args, **kwargs):

--- a/ap/schedules/models.py
+++ b/ap/schedules/models.py
@@ -94,6 +94,9 @@ class EventGroup(models.Model):
 
     # which days this event repeats, starting with Monday (0) through LD (6)
     # i.e. an event that repeats on Tuesday and Thursday would be (1,3)
+    name = models.CharField(max_length=30)
+    code = models.CharField(max_length=10)
+    description = models.CharField(max_length=250, blank=True)
     repeat = models.CommaSeparatedIntegerField(max_length=20)
     duration = models.PositiveSmallIntegerField()  # how many weeks this event repeats
 
@@ -120,6 +123,9 @@ class EventGroup(models.Model):
         # override delete(): ensure all events in eventgroup are also deleted
         Event.objects.filter(eventgroup=self.id).delete()
         super(EventGroup, self).delete(*args, **kwargs)
+
+    def __unicode__(self):
+        return self.name + " group"
 
 
 class Schedule(models.Model):

--- a/ap/schedules/models.py
+++ b/ap/schedules/models.py
@@ -57,7 +57,7 @@ class Event(models.Model):
     description = models.CharField(max_length=250, blank=True)
 
     # a groupID. used to group repeating events
-    group = models.ForeignKey('EventGroup', blank=True, null=True)
+    group = models.ForeignKey('EventGroup', blank=True, null=True, related_name="events")
 
     # if this event is a class, relate it
     classs = models.ForeignKey(Class, blank=True, null=True, verbose_name='class')  # class is a reserved keyword :(
@@ -134,7 +134,7 @@ class EventGroup(models.Model):
 class Schedule(models.Model):
 
     # which trainee this schedule belongs to
-    trainee = models.ForeignKey(Trainee)
+    trainee = models.ForeignKey(Trainee, related_name="schedule")
 
     # which term this schedule applies to
     term = models.ForeignKey(Term)

--- a/ap/schedules/models.py
+++ b/ap/schedules/models.py
@@ -124,6 +124,9 @@ class EventGroup(models.Model):
         Event.objects.filter(eventgroup=self.id).delete()
         super(EventGroup, self).delete(*args, **kwargs)
 
+    def get_absolute_url(self):
+        return reverse('schedules:eventgroup-detail', kwargs={'pk': self.pk})
+
     def __unicode__(self):
         return self.name + " group"
 

--- a/ap/schedules/templates/schedules/eventgroup_create.html
+++ b/ap/schedules/templates/schedules/eventgroup_create.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% load staticfiles %}
+{% load bootstrap3 %}
+{% bootstrap_css %}
+{% bootstrap_javascript %}
+{% bootstrap_messages %}
+
+{% block title %}Create Repeating Event{% endblock %}
+
+{% block media %}
+
+    {{ block.super }}
+    {{ form.media }}
+    <link href="/static/css/select2-bootstrap.css" type="text/css" media="screen" rel="stylesheet">
+    
+{% endblock %}
+
+{% block content %}
+
+    <h2>Create Repeating Event</h2>
+
+    <form id="eventForm" action="" method="post">{% csrf_token %}
+        {% bootstrap_form form %}
+        <button type="button" data-toggle="modal" data-target="#trainee_select">Add Trainee Group</button>
+        {% buttons %}
+            <button type="submit" class="btn btn-primary" form="eventForm">
+                Create
+            </button>
+        {% endbuttons %}
+    </form>
+
+    {% include 'schedules/trainee_select_modal.html' %}
+    
+
+{% endblock %}

--- a/ap/schedules/templates/schedules/eventgroup_create.html
+++ b/ap/schedules/templates/schedules/eventgroup_create.html
@@ -19,7 +19,7 @@
 
     <h2>Create Repeating Event</h2>
 
-    <form id="eventForm" action="" method="post">{% csrf_token %}
+    <form id="eventForm" class="col-md-6" action="" method="post">{% csrf_token %}
         {% bootstrap_form form %}
         <button type="button" data-toggle="modal" data-target="#trainee_select">Add Trainee Group</button>
         {% buttons %}

--- a/ap/schedules/templates/schedules/eventgroup_detail.html
+++ b/ap/schedules/templates/schedules/eventgroup_detail.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% load staticfiles %}
+
+{% block content %}
+    <h2>{{ eventgroup.name }} <br>
+    <small>{{ eventgroup.code }}</small>
+    </h2>
+
+    <p class="lead">{{ eventgroup.description }}</p>
+
+
+    <table class="table">
+        <tr><td>Repeat:</td>
+            <td>{{ eventgroup.repeat }}</td></tr>
+        <tr><td>Duration:</td>
+            <td>{{ eventgroup.duration }} weeks</td></tr>
+    </table>
+
+    <h4>Events in this Group</h4>
+    {% if eventgroup.event_set.all %}
+        <ul>
+        {% for event in  eventgroup.event_set.all %}
+            <li><a href="{{ event.get_absolute_url }}">{{ event }}</a></li>
+        {% endfor %}
+        </ul>
+    {% else %}
+        None
+    {% endif %}
+
+{% endblock %}

--- a/ap/schedules/urls.py
+++ b/ap/schedules/urls.py
@@ -10,5 +10,6 @@ urlpatterns = patterns('',
     url(r'event/(?P<pk>\d+)/$', views.EventDetail.as_view(), name='event-detail'),
     url(r'event/(?P<pk>\d+)/update/$', views.EventUpdate.as_view(), name='event-update'),
     url(r'event/(?P<pk>\d+)/delete/$', views.EventDelete.as_view(), name='event-delete'),
-    url(r'eventgroup/create/$', views.EventGroupCreate.as_view(), name='event-create'),
+    url(r'eventgroup/create/$', views.EventGroupCreate.as_view(), name='eventgroup-create'),
+    url(r'eventgroup/(?P<pk>\d+)/$', views.EventGroupDetail.as_view(), name='eventgroup-detail'),
 )

--- a/ap/schedules/urls.py
+++ b/ap/schedules/urls.py
@@ -10,4 +10,5 @@ urlpatterns = patterns('',
     url(r'event/(?P<pk>\d+)/$', views.EventDetail.as_view(), name='event-detail'),
     url(r'event/(?P<pk>\d+)/update/$', views.EventUpdate.as_view(), name='event-update'),
     url(r'event/(?P<pk>\d+)/delete/$', views.EventDelete.as_view(), name='event-delete'),
+    url(r'eventgroup/create/$', views.EventGroupCreate.as_view(), name='event-create'),
 )

--- a/ap/schedules/utils.py
+++ b/ap/schedules/utils.py
@@ -1,0 +1,6 @@
+import datetime
+
+def next_dow(d,day):
+    while d.weekday()!=day:
+        d+=datetime.timedelta(1)
+    return d  

--- a/ap/schedules/views.py
+++ b/ap/schedules/views.py
@@ -9,7 +9,7 @@ from bootstrap3_datetime.widgets import DateTimePicker
 from rest_framework import viewsets
 
 from .models import Schedule, ScheduleTemplate, Event, EventGroup
-from .forms import EventForm, TraineeSelectForm
+from .forms import EventForm, TraineeSelectForm, EventGroupForm
 from .serializers import EventSerializer, ScheduleSerializer
 from terms.models import Term
 
@@ -32,8 +32,21 @@ class ScheduleDetail(generic.DetailView):
         return Schedule.objects.filter(trainee=self.request.user.trainee).filter(term=Term.current_term())
 
 
+class EventGroupCreate(generic.FormView):
+    template_name = 'schedules/eventgroup_create.html'
+    form_class = EventGroupForm
+
+    def get_context_data(self, **kwargs):
+        context = super(EventGroupCreate, self).get_context_data(**kwargs)
+        context['trainee_select_form'] = TraineeSelectForm()
+        return context
+
+    def form_valid(self, form):
+        # custom logic (do something)
+        return super(EventGroupCreate, self).form_valid(form)
+
+
 class EventCreate(generic.CreateView):
-    model = Event
     template_name = 'schedules/event_create.html'
     form_class = EventForm
 

--- a/ap/schedules/views.py
+++ b/ap/schedules/views.py
@@ -44,23 +44,25 @@ class EventGroupCreate(generic.FormView):
     def form_valid(self, form):
         # custom logic (do something)
 
-        eg = EventGroup.create(
-            repeat=",".join(form.cleaned_data['repeat']), 
-            duration=form.cleaned_data['duration'])
+        eg = EventGroup(
+            repeat = ",".join(form.cleaned_data['repeat']), 
+            duration = form.cleaned_data['duration'])
+        eg.save()
 
-        e = Event.create(
-            name=form.cleaned_data['name'],
-            code=form.cleaned_data['code'],
-            description=form.cleaned_data['description'],
-            classs=form.cleaned_data['classs'],
-            type=form.cleaned_data['type'],
-            monitor=form.cleaned_data['monitor'],
-            term=form.cleaned_data['term'],
-            start=form.cleaned_data['start'],
-            end=form.cleaned_data['end'],)
+        e = Event(
+            name = form.cleaned_data['name'],
+            code = form.cleaned_data['code'],
+            description = form.cleaned_data['description'],
+            classs = form.cleaned_data['classs'],
+            type = form.cleaned_data['type'],
+            monitor = form.cleaned_data['monitor'],
+            term = form.cleaned_data['term'],
+            start = form.cleaned_data['start'],
+            end = form.cleaned_data['end'],
+            group = eg,)
 
         eg.create_children(e)
-        
+
         return super(EventGroupCreate, self).form_valid(form)
 
 

--- a/ap/schedules/views.py
+++ b/ap/schedules/views.py
@@ -43,6 +43,24 @@ class EventGroupCreate(generic.FormView):
 
     def form_valid(self, form):
         # custom logic (do something)
+
+        eg = EventGroup.create(
+            repeat=",".join(form.cleaned_data['repeat']), 
+            duration=form.cleaned_data['duration'])
+
+        e = Event.create(
+            name=form.cleaned_data['name'],
+            code=form.cleaned_data['code'],
+            description=form.cleaned_data['description'],
+            classs=form.cleaned_data['classs'],
+            type=form.cleaned_data['type'],
+            monitor=form.cleaned_data['monitor'],
+            term=form.cleaned_data['term'],
+            start=form.cleaned_data['start'],
+            end=form.cleaned_data['end'],)
+
+        eg.create_children(e)
+        
         return super(EventGroupCreate, self).form_valid(form)
 
 

--- a/ap/schedules/views.py
+++ b/ap/schedules/views.py
@@ -35,6 +35,7 @@ class ScheduleDetail(generic.DetailView):
 class EventGroupCreate(generic.FormView):
     template_name = 'schedules/eventgroup_create.html'
     form_class = EventGroupForm
+    #success_url = 
 
     def get_context_data(self, **kwargs):
         context = super(EventGroupCreate, self).get_context_data(**kwargs)
@@ -67,6 +68,11 @@ class EventGroupCreate(generic.FormView):
         eg.create_children(e)
 
         return super(EventGroupCreate, self).form_valid(form)
+
+
+class EventGroupDetail(generic.DetailView):
+    model = EventGroup
+    context_object_name = "eventgroup"
 
 
 class EventCreate(generic.CreateView):

--- a/ap/schedules/views.py
+++ b/ap/schedules/views.py
@@ -35,7 +35,6 @@ class ScheduleDetail(generic.DetailView):
 class EventGroupCreate(generic.FormView):
     template_name = 'schedules/eventgroup_create.html'
     form_class = EventGroupForm
-    #success_url = 
 
     def get_context_data(self, **kwargs):
         context = super(EventGroupCreate, self).get_context_data(**kwargs)
@@ -52,6 +51,7 @@ class EventGroupCreate(generic.FormView):
             repeat = ",".join(form.cleaned_data['repeat']), 
             duration = form.cleaned_data['duration'])
         eg.save()
+        self.success_url = eg.get_absolute_url()
 
         e = Event(
             name = form.cleaned_data['name'],

--- a/ap/schedules/views.py
+++ b/ap/schedules/views.py
@@ -45,6 +45,9 @@ class EventGroupCreate(generic.FormView):
         # custom logic (do something)
 
         eg = EventGroup(
+            name = form.cleaned_data['name'],
+            code = form.cleaned_data['code'],
+            description = form.cleaned_data['description'],
             repeat = ",".join(form.cleaned_data['repeat']), 
             duration = form.cleaned_data['duration'])
         eg.save()


### PR DESCRIPTION
Allows for creation of `EventGroups`, aka repeating events.

Not 100% complete, but at the point where I feel I can submit a pull request. Basically throws up a form similar for `Event` creation, but asks for which days of the week the `Event` repeats on and how many weeks it should repeat. Hides the logic of having `EventGroup`s from the user, just labels it as a repeating event.

(missing a success URL)

**TODO:**
- [x] success URL for form submission
- [x] `EventGroup` `DetailView`
- [x] assign trainees on event creation? (since the field is there)
- [ ] page loads slowly... optimize?