### PR TITLE
DB Optimization.

### DIFF
--- a/ap/accounts/admin.py
+++ b/ap/accounts/admin.py
@@ -4,10 +4,12 @@ from django.contrib.admin import SimpleListFilter
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.admin import Group, User
 from django.utils.translation import ugettext_lazy as _
+from django_select2 import *
 
-from .models import User, Trainee, TrainingAssistant
+from .models import User, Trainee, TrainingAssistant, Locality
 from aputils.admin import VehicleInline, EmergencyInfoInline
 from django_extensions.admin import ForeignKeyAutocompleteAdmin
+
 
 """" ACCOUNTS admin.py """
 
@@ -182,34 +184,48 @@ class FirstTermMentorListFilter(SimpleListFilter):
 			return q
 
 
+# Adding a custom TraineeAdminForm to use prefetch_related all the locality many-to-many relationship
+# to pre-cache the relationships and squash all the n+1 sql calls.
+class TraineeAdminForm(forms.ModelForm):
+  class Meta:
+    model = Trainee
+  locality = ModelSelect2MultipleField(queryset=Locality.objects.prefetch_related('city__state'),
+        required=False,
+        search_fields=['^city'],
+        widget=Select2MultipleWidget(
+            select2_options={
+                'width': '220px',
+            }
+        )) # could add state and country
+
+
 class TraineeAdmin(ForeignKeyAutocompleteAdmin):
+  form = TraineeAdminForm
 
-    # User is your FK attribute in your model
-    # first_name and email are attributes to search for in the FK model
-    related_search_fields = {
-        'account': ('firstname', 'lastname', 'email'),
-        'TA': ('account__firstname', 'account__lastname', 'account__email'),
-        'mentor': ('account__firstname', 'account__lastname', 'account__email'),
-        'spouse': ('account__firstname', 'account__lastname', 'account__email'),
-    }
+  # User is your FK attribute in your model
+  # first_name and email are attributes to search for in the FK model
+  related_search_fields = {
+      'account': ('firstname', 'lastname', 'email'),
+      'TA': ('account__firstname', 'account__lastname', 'account__email'),
+      'mentor': ('account__firstname', 'account__lastname', 'account__email'),
+      'spouse': ('account__firstname', 'account__lastname', 'account__email'),
+  }
 
-    search_fields = ['account__email', 'account__firstname', 'account__lastname']
+  search_fields = ['account__email', 'account__firstname', 'account__lastname']
 
-    fieldsets = (
-        (None, {
-            'fields': (('account', 'active',), 'type', 'locality', 'term',
-                ('date_begin', 'date_end',), ('married', 'spouse',),
-                ('TA', 'mentor',), 'team', ('house', 'bunk',), 'address',
-                'self_attendance',)
-        }),
-    )
-    list_display = ('__unicode__','current_term','_trainee_email','team', 'house',)
-    list_filter = ('active', CurrentTermListFilter,FirstTermMentorListFilter,)
-    inlines = [
-        VehicleInline, EmergencyInfoInline,
-    ]
-
-
+  fieldsets = (
+      (None, {
+          'fields': (('account', 'active',), 'type', 'locality', 'term',
+              ('date_begin', 'date_end',), ('married', 'spouse',),
+              ('TA', 'mentor',), 'team', ('house', 'bunk',), 'address',
+              'self_attendance',)
+      }),
+  )
+  list_display = ('__unicode__','current_term','_trainee_email','team', 'house',)
+  list_filter = ('active', CurrentTermListFilter,FirstTermMentorListFilter,)
+  inlines = [
+      VehicleInline, EmergencyInfoInline,
+  ]
 
 # Register the new Admin
 admin.site.register(User, APUserAdmin)

--- a/ap/leaveslips/forms.py
+++ b/ap/leaveslips/forms.py
@@ -12,7 +12,7 @@ class IndividualSlipForm(forms.ModelForm):
 
 class GroupSlipForm(forms.ModelForm):
 
-    trainees = forms.ModelMultipleChoiceField(queryset=Trainee.objects.filter(active=True))
+    trainees = forms.ModelMultipleChoiceField(queryset=Trainee.objects.select_related().filter(active=True))
 
     class Meta:
         model = GroupSlip

--- a/ap/schedules/forms.py
+++ b/ap/schedules/forms.py
@@ -10,9 +10,9 @@ from localities.models import Locality
 
 
 class EventForm(forms.ModelForm):
-    active_trainees = Trainee.objects.filter(active=True)
+    active_trainees = Trainee.objects.select_related().filter(active=True)
     trainees = ModelSelect2MultipleField(queryset=active_trainees, required=False, search_fields=['^first_name', '^last_name'])
-    
+
     class Meta:
         model = Event
         fields = ('type', 'name', 'code', 'description', 'classs', 'monitor', 'term', 'start', 'end')
@@ -27,7 +27,7 @@ class EventGroupForm(forms.ModelForm):
         ('1', 'Tuesday'),
         ('2', 'Wednesday'),
         ('3', 'Thursday'),
-        ('4', 'Friday'), 
+        ('4', 'Friday'),
         ('5', 'Saturday'),
         ('6', "Lord's Day"),
     )
@@ -35,7 +35,7 @@ class EventGroupForm(forms.ModelForm):
     repeat = forms.MultipleChoiceField(choices=DAYS, help_text="Which days this event repeats on")
     duration = forms.IntegerField(help_text="How many weeks this event repeats for")
     active_trainees = Trainee.objects.filter(active=True)
-    trainees = ModelSelect2MultipleField(queryset=active_trainees, required=False, search_fields=['^first_name', '^last_name']) 
+    trainees = ModelSelect2MultipleField(queryset=active_trainees, required=False, search_fields=['^first_name', '^last_name'])
 
     class Meta:
         model = Event
@@ -54,23 +54,23 @@ class TraineeSelectForm(forms.Form):
                     (3, '3'),
                     (4, '4'))
 
-    term = forms.MultipleChoiceField(choices=TERM_CHOICES, 
+    term = forms.MultipleChoiceField(choices=TERM_CHOICES,
         widget = forms.CheckboxSelectMultiple,
         required = False)
     gender = forms.ChoiceField(choices=User.GENDER,
         widget = forms.RadioSelect,
         required = False)
     hc = forms.BooleanField(required=False, label="House coordinators")
-    team_type = forms.MultipleChoiceField(choices=Team.TEAM_TYPES, 
+    team_type = forms.MultipleChoiceField(choices=Team.TEAM_TYPES,
         widget = forms.CheckboxSelectMultiple,
         required = False)
-    team = ModelSelect2MultipleField(queryset=Team.objects, 
-        required=False, 
+    team = ModelSelect2MultipleField(queryset=Team.objects,
+        required=False,
         search_fields=['^name'])
-    house = ModelSelect2MultipleField(queryset=House.objects.filter(used=True), 
-        required=False, 
+    house = ModelSelect2MultipleField(queryset=House.objects.filter(used=True),
+        required=False,
         search_fields=['^name'])
-    locality = ModelSelect2MultipleField(queryset=Locality.objects,
+    locality = ModelSelect2MultipleField(queryset=Locality.objects.prefetch_related('city__state'),
         required=False,
         search_fields=['^city']) # could add state and country
 


### PR DESCRIPTION
Fixes the following pages:
 - create event page
 - submit group leaveslip page
 - admin create trainee page

Optimized db queries by squashing all known n+1 calls. Substituted naive .all() with select_related and prefetch_related calls to pre join tables and pre-populate cache to save database roundtrips.

Notes for future reference on how to use select_related vs. prefetch_related

select_related is for one-to-many while prefetch_related is for many-to-many

prefetch_related, on the other hand, does a separate lookup for each relationship, and does the ‘joining’ in Python. This allows it to prefetch many-to-many and many-to-one objects, which cannot be done usingselect_related, in addition to the foreign key and one-to-one relationships that are supported byselect_related. It also supports prefetching of GenericRelation and GenericForeignKey.

SQL difference between prefetch_related (1) and select_related (2)

select_related gets inheritance relationships automatically

(1)

SELECT "accounts_trainee"."id", "accounts_trainee"."account_id", "accounts_trainee"."active", "accounts_trainee"."date_created", "accounts_trainee"."type", "accounts_trainee"."date_begin", "accounts_trainee"."date_end", "accounts_trainee"."TA_id", "accounts_trainee"."mentor_id", "accounts_trainee"."team_id", "accounts_trainee"."house_id", "accounts_trainee"."bunk_id", "accounts_trainee"."married", "accounts_trainee"."spouse_id", "accounts_trainee"."address_id", "accounts_trainee"."self_attendance" FROM "accounts_trainee" WHERE "accounts_trainee"."active" =true


(2)

SELECT "accounts_trainee"."id", "accounts_trainee"."account_id", "accounts_trainee"."active", "accounts_trainee"."date_created", "accounts_trainee"."type", "accounts_trainee"."date_begin", "accounts_trainee"."date_end", "accounts_trainee"."TA_id", "accounts_trainee"."mentor_id", "accounts_trainee"."team_id", "accounts_trainee"."house_id", "accounts_trainee"."bunk_id", "accounts_trainee"."married", "accounts_trainee"."spouse_id", "accounts_trainee"."address_id", "accounts_trainee"."self_attendance", "accounts_user"."id", "accounts_user"."password", "accounts_user"."last_login", "accounts_user"."is_superuser", "accounts_user"."email", "accounts_user"."firstname", "accounts_user"."lastname", "accounts_user"."middlename", "accounts_user"."nickname", "accounts_user"."maidenname", "accounts_user"."gender", "accounts_user"."date_of_birth", "accounts_user"."phone", "accounts_user"."is_active", "accounts_user"."is_admin", "accounts_user"."is_staff" FROM "accounts_trainee" INNER JOIN"accounts_user" ON ( "accounts_trainee"."account_id" = "accounts_user"."id" ) WHERE"accounts_trainee"."active" = true
