### PR TITLE
Fix seating chart

### DIFF
--- a/ap/seating/static/seating/css/jquery.seat-charts.css
+++ b/ap/seating/static/seating/css/jquery.seat-charts.css
@@ -50,9 +50,9 @@ div.seatCharts-seat.focused {
 	background-color: #d3d3d3;
 }
 
-div.seatCharts-seat.available {
+/*div.seatCharts-seat.available {
 	background-color: white;
-}
+}*/
 
 div.seatCharts-seat.unavailable {
 	background-color: red;
@@ -66,3 +66,8 @@ li.seatCharts-legendItem {
 	margin-top: 10px;
 	line-height: 2;
 }
+
+/*
+div.seatCharts-seat:hover {
+	background-color: #d3d3d3;
+}*/

--- a/ap/seating/static/seating/css/seating.css
+++ b/ap/seating/static/seating/css/seating.css
@@ -20,9 +20,9 @@
   margin: 10px;
 }
 
-#submit-chart-form {
+/*#submit-chart-form {
   display: none;
-}
+}*/
 
 #chart-name {
   width: 250px;
@@ -35,7 +35,7 @@
 }
 
 #trainee-name {
-  margin: 10px;
+  margin: 0px;
 }
 
 #edit-seat {

--- a/ap/seating/static/seating/js/seat-charts-init.js
+++ b/ap/seating/static/seating/js/seat-charts-init.js
@@ -1,0 +1,130 @@
+// Creating the seating chart object after loading data
+
+var scObject = {
+  map: seats,
+  naming: {
+    top: true,
+    left: true,
+  },
+  click: function (ev, elem) {
+    // var elem = this.settings.$node[0];
+    var popover = $(elem).popover({
+      placement: 'right auto',
+      trigger: 'manual',
+      content: '<input class="form-control" placeholder="Trainee name" id="trainee-name"/>',
+      html: true
+    }).popover('show');
+
+    var seatId = "#" + elem.id;
+    var rc_list = elem.id.split('_');
+    var row = rc_list[0];
+    var column = rc_list[1];
+
+    var input = popover.find("#trainee-name");
+
+  }
+};
+
+$(document).ready(function() {
+  // Initialize Seating Chart
+
+  sc = $('#seat-map').seatCharts(scObject);
+
+  // Popover Logic
+
+  $('body').on('shown.bs.popover', function(e) {
+    console.log('popover shown', e);
+
+    var elem = $(e.target);
+    var rcpair = elem.attr('id').split('_');
+    var row = rcpair[0] - 1;
+    var column = rcpair[1] - 1;
+    var popover = elem.data('bs.popover').$tip;
+    var input = popover.find('input');
+
+    input.autocomplete({
+      lookup: traineeList,
+      autoSelectFirst: true,
+      onSelect: function(selection) {
+        console.log('onselect', selection, selection.value);
+        elem.text(selection.value);
+
+        seats.grid[row][column].pk = selection.id;
+        seats.grid[row][column].name = selection.value;
+        elem.popover('destroy');
+        // elem.blur();
+      }
+    });
+
+    input.focus();
+    input.val(elem.text());
+    input.select();
+  });
+
+  $('body').on('blur', '#trainee-name', function(e) {
+    console.log('blur global', e);
+    $(e.currentTarget).parent().parent().popover('destroy');
+  });
+
+
+  $("#submit-chart-form").submit(function (event) {
+    event.preventDefault();
+    if (seats.grid.length > 0) {
+      var chart = {
+        name: $("#chart-name").val(),
+        desc: '',
+        width: $("#width").val(),
+        height: $("#height").val(),
+        trainees: seats.grid,
+      }
+
+      if (chartId) {
+        chart.id = chartId;
+      }
+
+      $.ajax({
+        url: '/api/charts/',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify(chart),
+        success: function (data, status, jqXHR) {
+          $("#chart-submit-error").hide();
+          $("#chart-submit-success").show();
+          if (!chartId) {
+            window.location.href = menuUrl;
+          }
+          setTimeout(function() {
+            $("#chart-submit-success").slideUp(1000)
+          }, 5000);
+        },
+        error: function (jqXHR, textStatus, errorThrown ) {
+          console.log('Chart post error!');
+          console.log(jqXHR, textStatus, errorThrown);
+          $("#chart-submit-error").show();
+          $("#chart-submit-error").empty();
+          $("#chart-submit-error").append('Error! ' + errorThrown);
+        }
+      })
+    }
+  });
+
+  $("#width-height-form").submit(function (event) {
+    event.preventDefault();
+
+    $('#seat-map').empty();
+
+    var w = parseInt($("#width").val());
+    var h = parseInt($("#height").val());
+    $("#seat-map").css("width", ((w+2)*60).toString() + "px");
+
+    if (seats) {
+      seats.setDimensions(w, h);
+    } else {
+      seats = new Grid(w, h);
+    }
+
+    sc = $('#seat-map').seatCharts(scObject);
+
+  });
+
+});

--- a/ap/seating/templates/seating/chart_create.html
+++ b/ap/seating/templates/seating/chart_create.html
@@ -36,12 +36,15 @@
 <div id="seat-map"></div>
 
 <script type="text/javascript" src="{% static "seating/js/grid.js" %}"></script>
+  <script type="text/javascript" src="{% static "js/bootstrap.min.js" %}"></script>
 <script>
   var trainees = JSON.parse('{{trainees_bb}}'.replace(/&#39;/g, "'").replace(/&quot;/g,'"'));
-  var traineeNames = {};
+  var traineeList = [];
   for (var i = 0; i < trainees.length; i++) {
-    var name = trainees[i].firstname + ' ' + trainees[i].lastname;
-    traineeNames[name] = trainees[i].id;
+    traineeList.push({
+      value: trainees[i].firstname + ' ' + trainees[i].lastname,
+      id: trainees[i].id
+    });
   }
   //destroy trainee personal information
   trainees = null;
@@ -93,49 +96,52 @@
           left: true,
         },
         click: function (event) {
-          if (this.status() == 'available') {
-            $("#edit-seat").remove();
 
-            var seatId = "#" + this.settings.id;
-            var positioningStyle = "top:" + this.settings.$node[0].offsetTop + "px; left:" + this.settings.$node[0].offsetLeft + "px;";
-            $(seatId).after('<form class="form-inline" id="edit-seat" style="' + positioningStyle + '">');
-            $("#edit-seat").append('<input class="form-control" id="trainee-name"/>');
-            $("#edit-seat").append('<button id="" type="submit" class="btn btn-xs btn-default">Submit</button>');
+          console.log('hsdf');
+          // $("#edit-seat").remove();
+          $('.trainee-name').popover('destroy');
 
-            $("#trainee-name").focus();
+          var elem = this.settings.$node[0];
+          console.log('elem', elem);
 
-            $("#trainee-name").autocomplete({
-                lookup: Object.keys(traineeNames),
-                autoSelectFirst: true,
-            });
-            var row = this.settings.row;
-            var column = this.settings.column;
-            $("#edit-seat").submit(function(event) {
-              event.preventDefault();
-              var tn = $("#trainee-name").val();
-              $(seatId).text(tn);
-              seats.grid[row][column].pk = traineeNames[tn] ? traineeNames[tn] : tn;
-              seats.grid[row][column].name = tn;
-              $("#edit-seat").remove();
-              $(".selected").focus();
-              if (tn == '') {
-                $(".selected").removeClass("selected");
-                return 'selected';
+          var popover = $(elem).popover({
+            placement: 'right auto',
+            trigger: 'manual',
+            content: '<input class="form-control trainee-name" placeholder="Trainee name" id="trainee-name"/>',
+            html: true
+          }).popover('show');
+
+          var st = this.settings;
+          var seatId = "#" + st.id;
+          var row = st.row;
+          var column = st.column;
+
+          $("#trainee-name").autocomplete({
+              lookup: traineeList,
+              autoSelectFirst: true,
+              onSelect: function(selection) {
+                $(seatId).text(selection.value);
+                seats.grid[row][column].pk = selection.id;
+                seats.grid[row][column].name = selection.value;
+                popover.popover('destroy');
               }
-            });
+          });
 
-            $(".selected").removeClass("selected");
-                  
-            return 'selected';
-          } else if (this.status() == 'selected') {
-            //seat has been vacated
-            return 'available';
-          } else if (this.status() == 'unavailable') {
-            //seat has been filled
-            return 'unavailable';
-          } else {
-            return this.style();
-          }
+          $("#trainee-name").focus();
+
+          $("#trainee-name").on('blur', function(e) {
+            console.log('blur');
+          });
+
+          // } else if (this.status() == 'selected') {
+          //   //seat has been vacated
+          //   return 'available';
+          // } else if (this.status() == 'unavailable') {
+          //   //seat has been filled
+          //   return 'unavailable';
+          // } else {
+          //   return this.style();
+          // }
         }
       });
 

--- a/ap/seating/templates/seating/chart_create.html
+++ b/ap/seating/templates/seating/chart_create.html
@@ -4,6 +4,27 @@
 {% block scripts %}
   <script type="text/javascript" src="{% static "js/jquery.seat-charts.js" %}"></script>
   <script type="text/javascript" src="{% static "js/jquery.autocomplete.js" %}"></script>
+  <script type="text/javascript" src="{% static "seating/js/grid.js" %}"></script>
+  <script type="text/javascript" src="{% static "js/bootstrap.min.js" %}"></script>
+  <script>
+    var trainees = JSON.parse('{{trainees_bb}}'.replace(/&#39;/g, "'").replace(/&quot;/g,'"'));
+    var traineeList = [];
+    for (var i = 0; i < trainees.length; i++) {
+      traineeList.push({
+        value: trainees[i].firstname + ' ' + trainees[i].lastname,
+        id: trainees[i].id
+      });
+    }
+
+    var seats = new Grid(10, 10);
+
+    // Default value to get form submission to work
+    var chartId = undefined;
+    var menuUrl = "{% url 'seating:chart_list' %}";
+    var sc;
+
+  </script>
+  <script type="text/javascript" src="{% static "seating/js/seat-charts-init.js" %}"></script>
 {% endblock %}
 {% block references %}
   <link rel="stylesheet" type="text/css" href="{% static 'seating/css/seating.css' %}" />
@@ -21,9 +42,9 @@
   <div class="form-inline">
     <form id="width-height-form">
       <label for="width">Width</label>
-      <input type="number" class="form-control" id="width" min="1"/>
+      <input type="number" class="form-control" id="width" min="1" value="10"/>
       <label for="height">Height</label>
-      <input type="number" class="form-control" id="height" min="1"/>
+      <input type="number" class="form-control" id="height" min="1" value="10"/>
       <button type="submit" class="btn btn-default">Submit</button>
     </form>
     <form id="submit-chart-form">
@@ -35,165 +56,5 @@
 </div>
 <div id="seat-map"></div>
 
-<script type="text/javascript" src="{% static "seating/js/grid.js" %}"></script>
-  <script type="text/javascript" src="{% static "js/bootstrap.min.js" %}"></script>
-<script>
-  var trainees = JSON.parse('{{trainees_bb}}'.replace(/&#39;/g, "'").replace(/&quot;/g,'"'));
-  var traineeList = [];
-  for (var i = 0; i < trainees.length; i++) {
-    traineeList.push({
-      value: trainees[i].firstname + ' ' + trainees[i].lastname,
-      id: trainees[i].id
-    });
-  }
-  //destroy trainee personal information
-  trainees = null;
-
-  var sc;
-
-  $(document).ready(function() {
-    var seats = null;
-
-    //to hide edit seat form
-    $(document).mouseup(function (e) {
-        var container = $(".seatCharts-cell");
-        var form = $("#edit-seat")
-
-        // if the target of the click isn't the container nor a descendant of the container or the form
-        if ((!container.is(e.target) && container.has(e.target).length === 0) &&
-              (!form.is(e.target) && form.has(e.target).length === 0))
-        {
-          $("#edit-seat").remove();
-        }
-    });
-
-    $("#width-height-form").submit(function (event) {
-      event.preventDefault();
-
-      $('#seat-map').empty();
-      $("#submit-chart-form").show();
-
-      var w = parseInt($("#width").val());
-      var h = parseInt($("#height").val());
-      $("#seat-map").css("width", ((w+2)*60).toString() + "px");
-
-      if (seats) {
-        seats.setDimensions(w, h);
-      } else {
-        seats = new Grid(w, h);
-      }
-
-      var map = [];
-      for (var i = 0; i < h; i++) {
-        map.push('a'.repeat(w));
-      }
-
-      sc = $('#seat-map').seatCharts({
-        map: map,
-        seats: {},
-        naming: {
-          top: true,
-          left: true,
-        },
-        click: function (event) {
-
-          console.log('hsdf');
-          // $("#edit-seat").remove();
-          $('.trainee-name').popover('destroy');
-
-          var elem = this.settings.$node[0];
-          console.log('elem', elem);
-
-          var popover = $(elem).popover({
-            placement: 'right auto',
-            trigger: 'manual',
-            content: '<input class="form-control trainee-name" placeholder="Trainee name" id="trainee-name"/>',
-            html: true
-          }).popover('show');
-
-          var st = this.settings;
-          var seatId = "#" + st.id;
-          var row = st.row;
-          var column = st.column;
-
-          $("#trainee-name").autocomplete({
-              lookup: traineeList,
-              autoSelectFirst: true,
-              onSelect: function(selection) {
-                $(seatId).text(selection.value);
-                seats.grid[row][column].pk = selection.id;
-                seats.grid[row][column].name = selection.value;
-                popover.popover('destroy');
-              }
-          });
-
-          $("#trainee-name").focus();
-
-          $("#trainee-name").on('blur', function(e) {
-            console.log('blur');
-          });
-
-          // } else if (this.status() == 'selected') {
-          //   //seat has been vacated
-          //   return 'available';
-          // } else if (this.status() == 'unavailable') {
-          //   //seat has been filled
-          //   return 'unavailable';
-          // } else {
-          //   return this.style();
-          // }
-        }
-      });
-
-      for (var i = 0; i < h; i++) {
-        for (var j = 0; j < w; j++) {
-          var id = (i+1) + '_' + (j+1);
-          if (i <= seats.grid.length) {
-            if (j <= seats.grid[i].length && seats.grid[i][j].name != '') {
-              sc.get(id).node().text(seats.grid[i][j].name);
-            }
-          }
-        }
-      }
-    });
-
-    $("#submit-chart-form").submit(function (event) {
-      event.preventDefault();
-      if (seats.grid.length > 0) {
-        var chart = {
-          name: $("#chart-name").val(),
-          desc: '',
-          width: $("#width").val(),
-          height: $("#height").val(),
-          trainees: seats.grid,
-        }
-
-        $.ajax({
-          url: '/api/charts/',
-          type: 'POST',
-          contentType: 'application/json',
-          data: JSON.stringify(chart),
-          success: function (data, status, jqXHR) {
-            $("#chart-submit-error").hide();
-            $("#chart-submit-success").show();
-            window.location.href = "{% url 'seating:chart_list' %}";
-            setTimeout(function() {
-              $("#chart-submit-success").slideUp(1000)
-            }, 5000);
-
-          },
-          error: function (jqXHR, textStatus, errorThrown ) {
-            console.log('Chart post error!');
-            console.log(jqXHR, textStatus, errorThrown);
-            $("#chart-submit-error").show();
-            $("#chart-submit-error").empty();
-            $("#chart-submit-error").append('Error! ' + errorThrown);
-          }
-        })
-      }
-    });
-
-  });
-</script>
 
 {% endblock %}

--- a/ap/seating/templates/seating/chart_edit.html
+++ b/ap/seating/templates/seating/chart_edit.html
@@ -4,6 +4,37 @@
 {% block scripts %}
   <script type="text/javascript" src="{% static "js/jquery.seat-charts.js" %}"></script>
   <script type="text/javascript" src="{% static "js/jquery.autocomplete.js" %}"></script>
+  <script type="text/javascript" src="{% static "seating/js/grid.js" %}"></script>
+  <script>
+    var trainees = JSON.parse('{{trainees_bb}}'.replace(/&#39;/g, "'").replace(/&quot;/g,'"'));
+    var traineeList = [];
+    for (var i = 0; i < trainees.length; i++) {
+      traineeList.push({
+        value: trainees[i].firstname + ' ' + trainees[i].lastname,
+        id: trainees[i].id
+      });
+    }
+
+    var chart = JSON.parse('{{chart_bb}}'.replace(/&#39;/g, "'").replace(/&quot;/g,'"'));
+    chart = chart[0];
+    var chartId = {{chart_id}}
+    var seatsJSON = JSON.parse('{{seats_bb}}'.replace(/&#39;/g, "'").replace(/&quot;/g,'"'));
+
+    var seats = new Grid(chart.width, chart.height);
+
+    for (var i = 0; i < seatsJSON.length; i++) {
+      var pk = seatsJSON[i].trainee;
+      seats.grid[seatsJSON[i].y][seatsJSON[i].x].pk = pk;
+      for (var j = 0; j < trainees.length; j++) {
+        if (pk == trainees[j].id) {
+          seats.grid[seatsJSON[i].y][seatsJSON[i].x].name = trainees[j].firstname + ' ' + trainees[j].lastname;
+        }
+      }
+    }
+
+  </script>
+
+  <script type="text/javascript" src="{% static "seating/js/seat-charts-init.js" %}"></script>
 {% endblock %}
 {% block references %}
   <link rel="stylesheet" type="text/css" href="{% static 'seating/css/seating.css' %}" />
@@ -21,191 +52,18 @@
   <div class="form-inline">
     <form id="width-height-form">
       <label for="width">Width</label>
-      <input type="number" class="form-control" id="width" min="1"/>
+      <input type="number" class="form-control" id="width" min="1" value="{{ chart.width }}"/>
       <label for="height">Height</label>
-      <input type="number" class="form-control" id="height" min="1"/>
+      <input type="number" class="form-control" id="height" min="1" value="{{ chart.height }}"/>
       <button type="submit" class="btn btn-default">Submit</button>
     </form>
     <form id="submit-chart-form">
       <label for="chart-name">Name</label>
-      <input type="text" class="form-control" id="chart-name" maxlength="100"/>
+      <input type="text" class="form-control" id="chart-name" maxlength="100" value="{{ chart.name }}"/>
       <button type="submit" class="btn btn-default">Submit</button>
     </form>
   </div>
 </div>
 <div id="seat-map"></div>
-
-<script type="text/javascript" src="{% static "seating/js/grid.js" %}"></script>
-<script>
-  var trainees = JSON.parse('{{trainees_bb}}'.replace(/&#39;/g, "'").replace(/&quot;/g,'"'));
-  var traineeList = [];
-  for (var i = 0; i < trainees.length; i++) {
-    traineeList.push({
-      value: trainees[i].firstname + ' ' + trainees[i].lastname,
-      id: trainees[i].id
-    });
-  }
-
-  var chart = JSON.parse('{{chart_bb}}'.replace(/&#39;/g, "'").replace(/&quot;/g,'"'));
-  chart = chart[0];
-  var chartId = {{chart_id}}
-  var seatsJSON = JSON.parse('{{seats_bb}}'.replace(/&#39;/g, "'").replace(/&quot;/g,'"'));
-
-  var seats = new Grid(chart.width, chart.height);
-
-  for (var i = 0; i < seatsJSON.length; i++) {
-    var pk = seatsJSON[i].trainee;
-    seats.grid[seatsJSON[i].y][seatsJSON[i].x].pk = pk;
-    for (var j = 0; j < trainees.length; j++) {
-      if (pk == trainees[j].id) {
-        seats.grid[seatsJSON[i].y][seatsJSON[i].x].name = trainees[j].firstname + ' ' + trainees[j].lastname;
-      }
-    }
-  }
-
-  var map = [];
-  for (var i = 0; i < chart.height; i++) {
-    map.push('a'.repeat(chart.width));
-  }
-
-  console.log('map', map)
-
-  var scObject = {
-    map: seats,
-    seats: seats,
-    naming: {
-      top: true,
-      left: true,
-    },
-    click: function (ev, elem) {
-
-      console.log('hsdf', ev, elem);
-
-      // var elem = this.settings.$node[0];
-      console.log('elem', elem);
-
-      var popover = $(elem).popover({
-        placement: 'right auto',
-        trigger: 'manual',
-        content: '<input class="form-control" placeholder="Trainee name" id="trainee-name"/>',
-        html: true
-      }).popover('show');
-
-      var st = this.settings;
-      var seatId = "#" + elem.id;
-      var rc_list = elem.id.split('_');
-      var row = rc_list[0];
-      var column = rc_list[1];
-
-      var input = popover.find("#trainee-name");
-
-      // input.autocomplete({
-      //   lookup: traineeList,
-      //   autoSelectFirst: true,
-      //   onSelect: function(selection) {
-      //     $(seatId).text(selection.value);
-      //     seats.grid[row][column].pk = selection.id;
-      //     seats.grid[row][column].name = selection.value;
-      //     popover.popover('destroy');
-      //   }
-      // });
-
-    }
-  };
-
-  $(document).ready(function() {
-    $('body').on('shown.bs.popover', function(e) {
-      console.log('popover shown', e, $(e.target).popover());
-
-      var elem = $(e.target);
-      var rcpair = elem.attr('id').split('_');
-      var row = rcpair[0] - 1;
-      var column = rcpair[1] - 1;
-      var input = elem.data('bs.popover').$tip.find('input');
-
-      input.autocomplete({
-        lookup: traineeList,
-        autoSelectFirst: true,
-        onSelect: function(selection) {
-          elem.text(selection.value);
-
-          seats.grid[row][column].pk = selection.id;
-          seats.grid[row][column].name = selection.value;
-          elem.popover('destroy');
-        }
-      });
-
-      input.focus();
-    })
-
-    $('body').on('blur', '#trainee-name', function(e) {
-      console.log('blur global', e);
-
-      $(e.currentTarget).parent().parent().popover('destroy');
-    })
-
-
-    $("#submit-chart-form").show();
-    $("#chart-name").val(chart.name);
-    $("#width").val(chart.width);
-    $("#height").val(chart.height);
-
-    sc = $('#seat-map').seatCharts(scObject);
-
-    $("#width-height-form").submit(function (event) {
-      event.preventDefault();
-
-      $('#seat-map').empty();
-
-      var w = parseInt($("#width").val());
-      var h = parseInt($("#height").val());
-      $("#seat-map").css("width", ((w+2)*60).toString() + "px");
-
-
-      // scObject.map = map
-
-      seats.setDimensions(w, h);
-
-      sc = $('#seat-map').seatCharts(scObject);
-
-    });
-
-    $("#submit-chart-form").submit(function (event) {
-      event.preventDefault();
-      if (seats.grid.length > 0) {
-        var chart = {
-          id: chartId,
-          name: $("#chart-name").val(),
-          desc: '',
-          width: $("#width").val(),
-          height: $("#height").val(),
-          trainees: seats.grid,
-        }
-
-        $.ajax({
-          url: '/api/charts/',
-          type: 'POST',
-          contentType: 'application/json',
-          data: JSON.stringify(chart),
-          success: function (data, status, jqXHR) {
-            $("#chart-submit-error").hide();
-            $("#chart-submit-success").show();
-            setTimeout(function() {
-              $("#chart-submit-success").slideUp(1000)
-            }, 5000);
-          },
-          error: function (jqXHR, textStatus, errorThrown ) {
-            console.log('Chart post error!');
-            console.log(jqXHR, textStatus, errorThrown);
-            $("#chart-submit-error").show();
-            $("#chart-submit-error").empty();
-            $("#chart-submit-error").append('Error! ' + errorThrown);
-          }
-        })
-      }
-    });
-
-  });
-</script>
 
 {% endblock %}

--- a/ap/seating/templates/seating/chart_edit.html
+++ b/ap/seating/templates/seating/chart_edit.html
@@ -38,10 +38,12 @@
 <script type="text/javascript" src="{% static "seating/js/grid.js" %}"></script>
 <script>
   var trainees = JSON.parse('{{trainees_bb}}'.replace(/&#39;/g, "'").replace(/&quot;/g,'"'));
-  var traineeNames = {};
+  var traineeList = [];
   for (var i = 0; i < trainees.length; i++) {
-    var name = trainees[i].firstname + ' ' + trainees[i].lastname;
-    traineeNames[name] = trainees[i].id;
+    traineeList.push({
+      value: trainees[i].firstname + ' ' + trainees[i].lastname,
+      id: trainees[i].id
+    });
   }
 
   var chart = JSON.parse('{{chart_bb}}'.replace(/&#39;/g, "'").replace(/&quot;/g,'"'));
@@ -60,99 +62,95 @@
       }
     }
   }
-  //destroy trainee personal information
-  trainees = null;
 
   var map = [];
   for (var i = 0; i < chart.height; i++) {
     map.push('a'.repeat(chart.width));
   }
 
+  console.log('map', map)
+
   var scObject = {
-    map: map,
-    seats: {},
+    map: seats,
+    seats: seats,
     naming: {
       top: true,
       left: true,
     },
-    click: function (event) {
-      if (this.status() == 'available') {
-        $("#edit-seat").remove();
+    click: function (ev, elem) {
 
-        var seatId = "#" + this.settings.id;
-        var positioningStyle = "top:" + this.settings.$node[0].offsetTop + "px; left:" + this.settings.$node[0].offsetLeft + "px;";
-        $(seatId).after('<form class="form-inline" id="edit-seat" style="' + positioningStyle + '">');
-        $("#edit-seat").append('<input class="form-control" id="trainee-name"/>');
-        $("#edit-seat").append('<button id="" type="submit" class="btn btn-xs btn-default">Submit</button>');
+      console.log('hsdf', ev, elem);
 
-        $("#trainee-name").focus();
+      // var elem = this.settings.$node[0];
+      console.log('elem', elem);
 
-        $("#trainee-name").autocomplete({
-            lookup: Object.keys(traineeNames),
-            autoSelectFirst: true,
-        });
-        var row = this.settings.row;
-        var column = this.settings.column;
-        $("#edit-seat").submit(function(event) {
-          event.preventDefault();
-          var tn = $("#trainee-name").val();
-          $(seatId).text(tn);
-          seats.grid[row][column].pk = traineeNames[tn] ? traineeNames[tn] : tn;
-          seats.grid[row][column].name = tn;
-          $("#edit-seat").remove();
-          $(".selected").focus();
-          if (tn == '') {
-            $(".selected").removeClass("selected");
-            return 'selected';
-          }
-        });
+      var popover = $(elem).popover({
+        placement: 'right auto',
+        trigger: 'manual',
+        content: '<input class="form-control" placeholder="Trainee name" id="trainee-name"/>',
+        html: true
+      }).popover('show');
 
-        $(".selected").removeClass("selected");
-              
-        return 'selected';
-      } else if (this.status() == 'selected') {
-        //seat has been vacated
-        return 'available';
-      } else if (this.status() == 'unavailable') {
-        //seat has been filled
-        return 'unavailable';
-      } else {
-        return this.style();
-      }
+      var st = this.settings;
+      var seatId = "#" + elem.id;
+      var rc_list = elem.id.split('_');
+      var row = rc_list[0];
+      var column = rc_list[1];
+
+      var input = popover.find("#trainee-name");
+
+      // input.autocomplete({
+      //   lookup: traineeList,
+      //   autoSelectFirst: true,
+      //   onSelect: function(selection) {
+      //     $(seatId).text(selection.value);
+      //     seats.grid[row][column].pk = selection.id;
+      //     seats.grid[row][column].name = selection.value;
+      //     popover.popover('destroy');
+      //   }
+      // });
+
     }
-  }
+  };
 
   $(document).ready(function() {
+    $('body').on('shown.bs.popover', function(e) {
+      console.log('popover shown', e, $(e.target).popover());
+
+      var elem = $(e.target);
+      var rcpair = elem.attr('id').split('_');
+      var row = rcpair[0] - 1;
+      var column = rcpair[1] - 1;
+      var input = elem.data('bs.popover').$tip.find('input');
+
+      input.autocomplete({
+        lookup: traineeList,
+        autoSelectFirst: true,
+        onSelect: function(selection) {
+          elem.text(selection.value);
+
+          seats.grid[row][column].pk = selection.id;
+          seats.grid[row][column].name = selection.value;
+          elem.popover('destroy');
+        }
+      });
+
+      input.focus();
+    })
+
+    $('body').on('blur', '#trainee-name', function(e) {
+      console.log('blur global', e);
+
+      $(e.currentTarget).parent().parent().popover('destroy');
+    })
+
+
     $("#submit-chart-form").show();
     $("#chart-name").val(chart.name);
     $("#width").val(chart.width);
     $("#height").val(chart.height);
 
-    var sc = $('#seat-map').seatCharts(scObject);
-
-    for (var i = 0; i < chart.height; i++) {
-      for (var j = 0; j < chart.width; j++) {
-        var id = (i+1) + '_' + (j+1);
-        if (i <= seats.grid.length) {
-          if (j <= seats.grid[i].length && seats.grid[i][j].name != '') {
-            sc.get(id).node().text(seats.grid[i][j].name);
-          }
-        }
-      }
-    }
-
-    //to hide edit seat form
-    $(document).mouseup(function (e) {
-        var container = $(".seatCharts-cell");
-        var form = $("#edit-seat")
-
-        // if the target of the click isn't the container nor a descendant of the container or the form
-        if ((!container.is(e.target) && container.has(e.target).length === 0) &&
-              (!form.is(e.target) && form.has(e.target).length === 0))
-        {
-          $("#edit-seat").remove();
-        }
-    });
+    sc = $('#seat-map').seatCharts(scObject);
 
     $("#width-height-form").submit(function (event) {
       event.preventDefault();
@@ -163,26 +161,13 @@
       var h = parseInt($("#height").val());
       $("#seat-map").css("width", ((w+2)*60).toString() + "px");
 
-      var map = [];
-      for (var i = 0; i < h; i++) {
-        map.push('a'.repeat(w));
-      }
 
-      scObject.map = map
-      sc = $('#seat-map').seatCharts(scObject);
+      // scObject.map = map
 
       seats.setDimensions(w, h);
-      
-      for (var i = 0; i < h; i++) {
-        for (var j = 0; j < w; j++) {
-          var id = (i+1) + '_' + (j+1);
-          if (i <= seats.grid.length) {
-            if (j <= seats.grid[i].length && seats.grid[i][j].name != '') {
-              sc.get(id).node().text(seats.grid[i][j].name);
-            }
-          }
-        }
-      }
+
+      sc = $('#seat-map').seatCharts(scObject);
+
     });
 
     $("#submit-chart-form").submit(function (event) {

--- a/ap/seating/views.py
+++ b/ap/seating/views.py
@@ -53,7 +53,7 @@ class ChartEditView(generic.DetailView):
         context['trainees_bb'] = l_render(BasicUserSerializer(trainees, many=True).data)
 
         chart = Chart.objects.filter(pk=self.pk)
-        context['chart'] = chart
+        context['chart'] = chart.get()
         context['chart_bb'] = l_render(ChartSerializer(chart, many=True).data)
         context['chart_id'] = self.pk
 

--- a/ap/static/js/jquery.seat-charts.js
+++ b/ap/static/js/jquery.seat-charts.js
@@ -100,8 +100,8 @@
 						.addClass(['seatCharts-seat', 'seatCharts-cell', 'available'].concat(
 							//let's merge custom user defined classes with standard JSC ones
 							fn.settings.classes,
-							typeof seatChartsSettings.seats[fn.settings.character] == "undefined" ?
-								[] : seatChartsSettings.seats[fn.settings.character].classes
+							typeof fn.settings.data.classes == "undefined" ?
+								[] : fn.settings.data.classes
 							).join(' '));
 
 					//basically a wrapper function
@@ -170,7 +170,7 @@
 		$('body')
 			.on('click', '.seatCharts-seat', function(e) {
 				// console.log('clicked', e, e.currentTarget, fn.click);
-				//
+				console.log("clicked", e);
 				fn.currentCell = $(e.currentTarget);
 
 				settings.click(e, e.currentTarget);
@@ -184,6 +184,11 @@
 
 
 		$(document).on('keydown', function (e) {
+
+			if ($(e.target).is('input')) {
+				console.log('in input, return');
+				return true;
+			}
 
 			//everything depends on the pressed key
 			switch (e.which) {
@@ -374,38 +379,6 @@
 			fn.append($row);
 		});
 
-		//if there're any legend items to be rendered
-		settings.legend.items.length ? (function(legend) {
-			//either use user-defined container or create our own and insert it right after the seat chart div
-			var $container = (legend.node || $('<div></div').insertAfter(fn))
-				.addClass('seatCharts-legend');
-
-			var $ul = $('<ul></ul>')
-				.addClass('seatCharts-legendList')
-				.appendTo($container);
-
-			$.each(legend.items, function(index, item) {
-				$ul.append(
-					$('<li></li>')
-						.addClass('seatCharts-legendItem')
-						.append(
-							$('<div></div>')
-								//merge user defined classes with our standard ones
-								.addClass(['seatCharts-seat', 'seatCharts-cell', item[1]].concat(
-									settings.classes,
-									typeof settings.seats[item[0]] == "undefined" ? [] : settings.seats[item[0]].classes).join(' ')
-								)
-						)
-						.append(
-							$('<span></span>')
-								.addClass('seatCharts-legendDescription')
-								.text(item[2])
-						)
-				);
-			});
-
-			return $container;
-		})(settings.legend) : null;
 
 		fn.attr({
 			tabIndex : 0

--- a/ap/static/js/jquery.seat-charts.js
+++ b/ap/static/js/jquery.seat-charts.js
@@ -7,22 +7,23 @@
  */
 
 (function($) {
-		
-	//'use strict';	
-		
+
+	//'use strict';
+
 	$.fn.seatCharts = function (setup) {
 
 		//if there's seatCharts object associated with the current element, return it
 		// if (this.data('seatCharts')) {
 		// 	return this.data('seatCharts');
 		// }
-		
+
 		var fn       = this,
 			seats    = {},
 			seatIds  = [],
 			legend,
 			settings = {
 				animate : false, //requires jQuery UI
+				hideEmptySeats: false,
 				naming  : {
 					top    : true,
 					left   : true,
@@ -32,79 +33,88 @@
 					getLabel : function (character, row, column) {
 						return column;
 					}
-					
+
 				},
 				legend : {
 					node   : null,
 					items  : []
 				},
-				click   : function() {
+				click   : function(e, elem) {
 
-					if (this.status() == 'available') {
-						return 'selected';
-					} else if (this.status() == 'selected') {
-						return 'available';
-					} else {
-						return this.style();
-					}
-					
+					console.log('default function', e, elem);
+
 				},
 				focus  : function() {
 
-					if (this.status() == 'available') {
-						return 'focused';
-					} else  {
-						return this.style();
-					}
 				},
 				blur   : function() {
-					return this.status();
 				},
 				seats   : {}
-			
-			},
+
+			};
+
+			var setCurrentCell = function(cur) {
+				$('.focused').removeClass('focused');
+				fn.currentCell = cur;
+				$(cur).addClass('focused');
+			}
+
+			var getRowCol = function(row, col) {
+				return $('#' + row + '_' + col);
+			}
+
+			// $('body').on('click', '.seatCharts-cell', function(e) {
+			// 	// console.log('clicked', e, e.currentTarget, fn.click);
+
+			// 	setup.click(e, e.currentTarget);
+			// });
+
 			//seat will be basically a seat object which we'll when generating the map
-			seat = (function(seatCharts, seatChartsSettings) {
+			var seat = (function(seatCharts, seatChartsSettings) {
 				return function (setup) {
 					var fn = this;
-					
+
 					fn.settings = $.extend({
 						status : 'available', //available, unavailable, selected
 						style  : 'available',
 						//make sure there's an empty hash if user doesn't pass anything
-						data   : seatChartsSettings.seats[setup.character] || {}
+						// data   : seatChartsSettings.seats || {}
 						//anything goes here?
 					}, setup);
 
 					fn.settings.$node = $('<div></div>');
-					
+
+					// console.log('node', fn.settings.$node, seatChartsSettings.seats, setup.character, fn.settings.id, fn.settings)
+					console.log('native rinting', fn.settings.data.name, fn.settings.map);
+
 					fn.settings.$node
 						.attr({
 							id             : fn.settings.id,
 							role           : 'checkbox',
 							'aria-checked' : false,
-							focusable      : true,
+							focusable      : false,
 							tabIndex       : -1 //manual focus
 						})
-						.text('')
+
+						.text(fn.settings.data.name)
 						.addClass(['seatCharts-seat', 'seatCharts-cell', 'available'].concat(
 							//let's merge custom user defined classes with standard JSC ones
-							fn.settings.classes, 
-							typeof seatChartsSettings.seats[fn.settings.character] == "undefined" ? 
+							fn.settings.classes,
+							typeof seatChartsSettings.seats[fn.settings.character] == "undefined" ?
 								[] : seatChartsSettings.seats[fn.settings.character].classes
 							).join(' '));
-					
+
 					//basically a wrapper function
 					fn.data = function() {
 						return fn.settings.data;
 					};
-					
+
 					fn.char = function() {
 						return fn.settings.character;
 					};
-					
+
 					fn.node = function() {
-						return fn.settings.$node;						
+						return fn.settings.$node;
 					};
 
 					/*
@@ -124,7 +134,7 @@
 								if (newStyle == oldStyle) {
 									return oldStyle;
 								}
-								
+
 								//focused is a special style which is not associated with status
 								fn.settings.status = newStyle != 'focused' ? newStyle : fn.settings.status;
 								fn.settings.$node
@@ -134,188 +144,133 @@
 								seatChartsSettings.animate ?
 									fn.settings.$node.switchClass(oldStyle, newStyle, 200) :
 									fn.settings.$node.removeClass(oldStyle).addClass(newStyle);
-									
+
 								return fn.settings.style = newStyle;
 							})(arguments[0]) : fn.settings.style;
 					};
-					
+
 					//either set or retrieve
 					fn.status = function() {
-	
-						return fn.settings.status = arguments.length == 1 ? 
+
+						return fn.settings.status = arguments.length == 1 ?
 							fn.style(arguments[0]) : fn.settings.status;
 					};
-					
-					//using immediate function to convienietly get shortcut variables
-					(function(seatSettings, character, seat) {
-						//attach event handlers
-						$.each(['click', 'focus', 'blur'], function(index, callback) {
-						
-							//we want to be able to call the functions for each seat object
-							fn[callback] = function() {
-								if (callback == 'focus') {
-									//if there's already a focused element, we have to remove focus from it first
-									if (seatCharts.attr('aria-activedescendant') !== undefined) {
-										seats[seatCharts.attr('aria-activedescendant')].blur();
-									}
-									seatCharts.attr('aria-activedescendant', seat.settings.id);
-									seat.node().focus();
-								}
-							
-								/*
-								 * User can pass his own callback function, so we have to first check if it exists
-								 * and if not, use our default callback.
-								 *
-								 * Each callback function is executed in the current seat context.
-								 */
-								return fn.style(typeof seatSettings[character][callback] === 'function' ?
-									seatSettings[character][callback].apply(seat) : seatChartsSettings[callback].apply(seat));
-							};
-							
-						});
-					//the below will become seatSettings, character, seat thanks to the immediate function		
-					})(seatChartsSettings.seats, fn.settings.character, fn);
-							
-					fn.node()
-						//the first three mouse events are simple
-						.on('click',      fn.click)
-						.on('mouseenter', fn.focus)
-						.on('mouseleave', fn.blur)
-						
-						//keydown requires quite a lot of logic, because we have to know where to move the focus
-						.on('keydown',    (function(seat, $seat) {
-						
-							return function (e) {
-								
-								var $newSeat;
-								
-								//everything depends on the pressed key
-								switch (e.which) {
-									//spacebar will just trigger the same event mouse click does
-									case 32:
-									case 13:
-										e.preventDefault();
-										seat.click();
-										break;
-									//UP & DOWN
-									case 40:
-									case 38:
-										e.preventDefault();
-										
-										/*
-										 * This is a recursive, immediate function which searches for the first "focusable" row.
-										 * 
-										 * We're using immediate function because we want a convenient access to some DOM elements
-										 * We're using recursion because sometimes we may hit an empty space rather than a seat.
-										 *
-										 */
-										$newSeat = (function findAvailable($rows, $seats, $currentRow) {
-											var $newRow;
-											
-											//let's determine which row should we move to
-											
-											if (!$rows.index($currentRow) && e.which == 38) {
-												//if this is the first row and user has pressed up arrow, move to the last row
-												$newRow = $rows.last();
-											} else if ($rows.index($currentRow) == $rows.length-1 && e.which == 40) {
-												//if this is the last row and user has pressed down arrow, move to the first row
-												$newRow = $rows.first();
-											} else {
-												//using eq to get an element at the desired index position
-												$newRow = $rows.eq(
-													//if up arrow, then decrement the index, if down increment it
-													$rows.index($currentRow) + (e.which == 38 ? (-1) : (+1))
-												);
-											}												
-											
-											//now that we know the row, let's get the seat using the current column position
-											$newSeat = $newRow.find('.seatCharts-seat,.seatCharts-space').eq($seats.index($seat));
-											
-											//if the seat we found is a space, keep looking further
-											return $newSeat.hasClass('seatCharts-space') ?
-												findAvailable($rows, $seats, $newRow) : $newSeat;
-											
-										})($seat
-											//get a reference to the parent container and then select all rows but the header
-												.parents('.seatCharts-container')
-												.find('.seatCharts-row:not(.seatCharts-header)'),
-											$seat
-											//get a reference to the parent row and then find all seat cells (both seats & spaces)
-												.parents('.seatCharts-row:first')
-												.find('.seatCharts-seat,.seatCharts-space'),
-											//get a reference to the current row
-											$seat.parents('.seatCharts-row:not(.seatCharts-header)')
-										);
-										
-										//we couldn't determine the new seat, so we better give up
-										if (!$newSeat.length) {
-											return;
-										}
-										
-										//remove focus from the old seat and put it on the new one
-										seat.blur();
-										seats[$newSeat.attr('id')].focus();
-										$newSeat.focus();
-										
-										//update our "aria" reference with the new seat id
-										seatCharts.attr('aria-activedescendant', $newSeat.attr('id'));
-																			
-										break;										
-									//LEFT & RIGHT
-									case 37:
-									case 39:
-										e.preventDefault();
-										/*
-										 * The logic here is slightly different from the one for up/down arrows.
-										 * User will be able to browse the whole map using just left/right arrow, because
-										 * it will move to the next row when we reach the right/left-most seat.
-										 */
-										$newSeat = (function($seats) {
-										
-											if (!$seats.index($seat) && e.which == 37) {
-												//user has pressed left arrow and we're currently on the left-most seat
-												return $seats.last();
-											} else if ($seats.index($seat) == $seats.length -1 && e.which == 39) {
-												//user has pressed right arrow and we're currently on the right-most seat
-												return $seats.first();
-											} else {
-												//simply move one seat left or right depending on the key
-												return $seats.eq($seats.index($seat) + (e.which == 37 ? (-1) : (+1)));
-											}
 
-										})($seat
-											.parents('.seatCharts-container:first')
-											.find('.seatCharts-seat:not(.seatCharts-space)'));
-										
-										if (!$newSeat.length) {
-											return;
-										}
-											
-										//handle focus
-										seat.blur();	
-										seats[$newSeat.attr('id')].focus();
-										$newSeat.focus();
-										
-										//update our "aria" reference with the new seat id
-										seatCharts.attr('aria-activedescendant', $newSeat.attr('id'));
-										break;	
-									default:
-										break;
-								
-								}
-							};
-								
-						})(fn, fn.node()));
-						//.appendTo(seatCharts.find('.' + row));
+					console.log('self', this, fn);
+
 
 				}
 			})(fn, settings);
-			
+
 		fn.addClass('seatCharts-container');
-		
+
 		//true -> deep copy!
-		$.extend(true, settings, setup);		
-		
+		$.extend(true, settings, setup);
+
+		$('body')
+			.on('click', '.seatCharts-seat', function(e) {
+				// console.log('clicked', e, e.currentTarget, fn.click);
+				//
+				fn.currentCell = $(e.currentTarget);
+
+				settings.click(e, e.currentTarget);
+			})
+			.on('mouseenter', '.seatCharts-seat', function(e) {
+				console.log('mouse enter', e, e.currentTarget);
+
+				setCurrentCell($(e.currentTarget));
+
+			});;
+
+
+		$(document).on('keydown', function (e) {
+
+			//everything depends on the pressed key
+			switch (e.which) {
+				//spacebar will just trigger the same event mouse click does
+				case 32:
+				case 13:
+					e.preventDefault();
+					$(fn.currentCell).click();
+					break;
+				//UP & DOWN
+				case 40:
+				case 38:
+					e.preventDefault();
+
+					var map = settings.map,
+							row, col;
+
+					if (!fn.currentCell) {
+						// if blank, default to 0
+						console.log('currentCell is null');
+
+						row = 0;
+						col = 0;
+					} else {
+						var rc_list = fn.currentCell.attr('id').split('_');
+						row = rc_list[0] - 1;
+						col = rc_list[1] - 1;
+
+						if (e.which == 38) {
+							console.log('up');
+							row = (map.height + row - 1) % map.height;
+						} else {
+							console.log('down');
+							row = (row + 1) % map.height;
+						}
+					}
+
+
+					console.log('setting', getRowCol(row, col));
+
+					setCurrentCell(getRowCol(row + 1, col + 1));
+
+					console.log('current', this.currentCell);
+
+					break;
+				//LEFT & RIGHT
+				case 37:
+				case 39:
+					e.preventDefault();
+
+
+					var map = settings.map,
+							row, col;
+
+
+
+					if (!fn.currentCell) {
+						// if blank, default to 0
+						console.log('currentCell is null');
+
+						row = 0;
+						col = 0;
+					} else {
+						var rc_list = fn.currentCell.attr('id').split('_');
+						row = rc_list[0] - 1;
+						col = rc_list[1] - 1;
+
+						if (e.which == 37) {
+							console.log('left');
+							col = (map.width + col - 1) % map.width;
+						} else {
+							console.log('right');
+							col = (col + 1) % map.width;
+						}
+					}
+
+					setCurrentCell(getRowCol(row + 1, col + 1));
+
+					break;
+				default:
+					break;
+
+			}
+		});
+
+		console.log('settings', settings);
+
 		//Generate default row ids unless user passed his own
 		settings.naming.rows = settings.naming.rows || (function(length) {
 			var rows = [];
@@ -323,8 +278,8 @@
 				rows.push(i);
 			}
 			return rows;
-		})(settings.map.length);
-		
+		})(settings.map.height);
+
 		//Generate default column ids unless user passed his own
 		settings.naming.columns = settings.naming.columns || (function(length) {
 			var columns = [];
@@ -332,17 +287,17 @@
 				columns.push(i);
 			}
 			return columns;
-		})(settings.map[0].split('').length);
-		
+		})(settings.map.width);
+
 		if (settings.naming.top) {
 			var $headerRow = $('<div></div>')
 				.addClass('seatCharts-row seatCharts-header');
-			
+
 			if (settings.naming.left) {
 				$headerRow.append($('<div></div>').addClass('seatCharts-cell'));
 			}
-			
-				
+
+
 			$.each(settings.naming.columns, function(index, value) {
 				$headerRow.append(
 					$('<div></div>')
@@ -351,14 +306,16 @@
 				);
 			});
 		}
-		
+
 		fn.append($headerRow);
-		
+
+		console.log('settings 2', settings, settings.map.grid.length);
+
 		//do this for each map row
-		$.each(settings.map, function(row, characters) {
+		$.each(settings.map.grid, function(row, list) {
 
 			var $row = $('<div></div>').addClass('seatCharts-row');
-				
+
 			if (settings.naming.left) {
 				$row.append(
 					$('<div></div>')
@@ -384,57 +341,49 @@
 			 * Allowed characters in labels are: 0-9, a-z, A-Z, _, ' ' (space)
 			 *
 			 */
-			 
-			$.each(characters.match(/[a-z_]{1}(\[[0-9a-z_]{0,}(,[0-9a-z_ ]+)?\])?/gi), function (column, characterParams) { 
-				var matches         = characterParams.match(/([a-z_]{1})(\[([0-9a-z_ ,]+)\])?/i),
-					//no matter if user specifies [] params, the character should be in the second element
-					character       = matches[1],
-					//check if user has passed some additional params to override id or label
-					params          = typeof matches[3] !== 'undefined' ? matches[3].split(',') : [],
-					//id param should be first
-					overrideId      = params.length ? params[0] : null,
-					//label param should be second
-					overrideLabel   = params.length === 2 ? params[1] : null;
-								
-				$row.append(character != '_' ?
+
+			$.each(list, function (column, cell) {
+
+				$row.append((!settings.hideEmptySeats || cell.pk) ?
 					//if the character is not an underscore (empty space)
 					(function(naming) {
-	
+
 						//so users don't have to specify empty objects
-						settings.seats[character] = character in settings.seats ? settings.seats[character] : {};
-	
-						var id = overrideId ? overrideId : naming.getId(character, naming.rows[row], naming.columns[column]);
+						// settings.seats[character] = character in settings.seats ? settings.seats[character] : {};
+
+						var id = naming.getId('a', naming.rows[row], naming.columns[column]);
 						seats[id] = new seat({
 							id        : id,
-							label     : overrideLabel ?
-								overrideLabel : naming.getLabel(character, naming.rows[row], naming.columns[column]),
+							label     : naming.getLabel('a', naming.rows[row], naming.columns[column]),
 							row       : row,
 							column    : column,
-							character : character
+							character : 'a',
+							data      : cell
+							// map       : settings.map.grid[row][column]
 						});
 
 						seatIds.push(id);
 						return seats[id].node();
-						
+
 					})(settings.naming) :
 					//this is just an empty space (_)
-					$('<div></div>').addClass('seatCharts-cell seatCharts-space')	
+					$('<div></div>').addClass('seatCharts-cell seatCharts-space')
 				);
 			});
-			
+
 			fn.append($row);
 		});
-	
+
 		//if there're any legend items to be rendered
 		settings.legend.items.length ? (function(legend) {
 			//either use user-defined container or create our own and insert it right after the seat chart div
 			var $container = (legend.node || $('<div></div').insertAfter(fn))
 				.addClass('seatCharts-legend');
-				
+
 			var $ul = $('<ul></ul>')
 				.addClass('seatCharts-legendList')
 				.appendTo($container);
-			
+
 			$.each(legend.items, function(index, item) {
 				$ul.append(
 					$('<li></li>')
@@ -443,7 +392,7 @@
 							$('<div></div>')
 								//merge user defined classes with our standard ones
 								.addClass(['seatCharts-seat', 'seatCharts-cell', item[1]].concat(
-									settings.classes, 
+									settings.classes,
 									typeof settings.seats[item[0]] == "undefined" ? [] : settings.seats[item[0]].classes).join(' ')
 								)
 						)
@@ -454,26 +403,20 @@
 						)
 				);
 			});
-			
+
 			return $container;
 		})(settings.legend) : null;
-	
+
 		fn.attr({
 			tabIndex : 0
 		});
-		
-		
+
+
 		//when container's focused, move focus to the first seat
 		fn.focus(function() {
-			if (fn.attr('aria-activedescendant')) {
-				seats[fn.attr('aria-activedescendant')].blur();
-			}
-				
-			fn.find('.seatCharts-seat:not(.seatCharts-space):first').focus();
-			seats[seatIds[0]].focus();
 
 		});
-	
+
 		//public methods of seatCharts
 		fn.data('seatCharts', {
 			seats   : seats,
@@ -481,9 +424,9 @@
 			//set for one, set for many, get for one
 			status: function() {
 				var fn = this;
-			
+
 				return arguments.length == 1 ? fn.seats[arguments[0]].status() : (function(seatsIds, newStatus) {
-				
+
 					return typeof seatsIds == 'string' ? fn.seats[seatsIds].status(newStatus) : (function() {
 						$.each(seatsIds, function(index, seatId) {
 							fn.seats[seatId].status(newStatus);
@@ -493,13 +436,13 @@
 			},
 			each  : function(callback) {
 				var fn = this;
-			
+
 				for (var seatId in fn.seats) {
 					if (false === callback.call(fn.seats[seatId], seatId)) {
 						return seatId;//return last checked
 					}
 				}
-				
+
 				return true;
 			},
 			node       : function() {
@@ -510,9 +453,9 @@
 
 			find       : function(query) {//D, a.available, unavailable
 				var fn = this;
-			
+
 				var seatSet = fn.set();
-			
+
 				//user searches just for a particual character
 				return query.length == 1 ? (function(character) {
 					fn.each(function() {
@@ -520,20 +463,20 @@
 							seatSet.push(this.settings.id, this);
 						}
 					});
-					
+
 					return seatSet;
 				})(query) : (function() {
 					//user runs a more sophisticated query, so let's see if there's a dot
 					return query.indexOf('.') > -1 ? (function() {
 						//there's a dot which separates character and the status
 						var parts = query.split('.');
-						
+
 						fn.each(function(seatId) {
 							if (this.char() == parts[0] && this.status() == parts[1]) {
 								seatSet.push(this.settings.id, this);
 							}
 						});
-						
+
 						return seatSet;
 					})() : (function() {
 						fn.each(function() {
@@ -542,15 +485,15 @@
 								seatSet.push(this.settings.id, this);
 							}
 						});
-						
+
 						return seatSet;
 					})();
 				})();
-				
+
 			},
 			set        : function set() {//inherits some methods
 				var fn = this;
-				
+
 				return {
 					seats      : [],
 					seatIds    : [],
@@ -592,24 +535,24 @@
 			get   : function(seatsIds) {
 				var fn = this;
 
-				return typeof seatsIds == 'string' ? 
+				return typeof seatsIds == 'string' ?
 					fn.seats[seatsIds] : (function() {
-						
+
 						var seatSet = fn.set();
-						
+
 						$.each(seatsIds, function(index, seatId) {
 							if (typeof fn.seats[seatId] === 'object') {
 								seatSet.push(seatId, fn.seats[seatId]);
 							}
 						});
-						
+
 						return seatSet;
 					})();
 			}
 		});
-		
+
 		return fn.data('seatCharts');
 	}
-	
-	
+
+
 })(jQuery);

--- a/ap/static/js/jquery.seat-charts.js
+++ b/ap/static/js/jquery.seat-charts.js
@@ -63,12 +63,6 @@
 				return $('#' + row + '_' + col);
 			}
 
-			// $('body').on('click', '.seatCharts-cell', function(e) {
-			// 	// console.log('clicked', e, e.currentTarget, fn.click);
-
-			// 	setup.click(e, e.currentTarget);
-			// });
-
 			//seat will be basically a seat object which we'll when generating the map
 			var seat = (function(seatCharts, seatChartsSettings) {
 				return function (setup) {
@@ -83,9 +77,6 @@
 					}, setup);
 
 					fn.settings.$node = $('<div></div>');
-
-					// console.log('node', fn.settings.$node, seatChartsSettings.seats, setup.character, fn.settings.id, fn.settings)
-					console.log('native rinting', fn.settings.data.name, fn.settings.map);
 
 					fn.settings.$node
 						.attr({
@@ -156,9 +147,6 @@
 							fn.style(arguments[0]) : fn.settings.status;
 					};
 
-					console.log('self', this, fn);
-
-
 				}
 			})(fn, settings);
 
@@ -169,15 +157,11 @@
 
 		$('body')
 			.on('click', '.seatCharts-seat', function(e) {
-				// console.log('clicked', e, e.currentTarget, fn.click);
-				console.log("clicked", e);
 				fn.currentCell = $(e.currentTarget);
 
 				settings.click(e, e.currentTarget);
 			})
 			.on('mouseenter', '.seatCharts-seat', function(e) {
-				console.log('mouse enter', e, e.currentTarget);
-
 				setCurrentCell($(e.currentTarget));
 
 			});;
@@ -186,7 +170,6 @@
 		$(document).on('keydown', function (e) {
 
 			if ($(e.target).is('input')) {
-				console.log('in input, return');
 				return true;
 			}
 
@@ -226,12 +209,7 @@
 						}
 					}
 
-
-					console.log('setting', getRowCol(row, col));
-
 					setCurrentCell(getRowCol(row + 1, col + 1));
-
-					console.log('current', this.currentCell);
 
 					break;
 				//LEFT & RIGHT
@@ -239,11 +217,8 @@
 				case 39:
 					e.preventDefault();
 
-
 					var map = settings.map,
 							row, col;
-
-
 
 					if (!fn.currentCell) {
 						// if blank, default to 0
@@ -273,8 +248,6 @@
 
 			}
 		});
-
-		console.log('settings', settings);
 
 		//Generate default row ids unless user passed his own
 		settings.naming.rows = settings.naming.rows || (function(length) {
@@ -313,8 +286,6 @@
 		}
 
 		fn.append($headerRow);
-
-		console.log('settings 2', settings, settings.map.grid.length);
 
 		//do this for each map row
 		$.each(settings.map.grid, function(row, list) {


### PR DESCRIPTION
Rewrote jquery-seating-charts to handle focus/blur events correctly now.

Supports keypress navigation, also bootstrap popover.

Also, absorbed grid object into library initialization for seating chart creation. No can handle arbitrary amount of data stored in each cell.

TODO: Doesn't have any too utility methods to give native access to grid object within seating chart yet.

Now, we locally maintain our fork of seating chart: https://github.com/attendanceproject/jQuery-Seat-Charts
