### PR TITLE
fix messages appearing twice

### DIFF
--- a/ap/templates/index.html
+++ b/ap/templates/index.html
@@ -7,9 +7,7 @@
 
 {% block messages %}
     <div id="messages">
-        {% for message in messages %}
-            {% bootstrap_messages message %}                
-        {% endfor %}
+        {% bootstrap_messages messages %}                
     </div>
 {% endblock %}
 

--- a/ap/templates/index.html
+++ b/ap/templates/index.html
@@ -7,7 +7,7 @@
 
 {% block messages %}
     <div id="messages">
-        {% bootstrap_messages messages %}                
+        {% bootstrap_messages %}                
     </div>
 {% endblock %}
 


### PR DESCRIPTION
`bootstrap_messages` renders each message already so for each message in there it was creating a whole list of messages again. This fixes it.