### PR TITLE
586/Bugfix

### DIFF
--- a/ap/absent_trainee_roster/utils.py
+++ b/ap/absent_trainee_roster/utils.py
@@ -1,7 +1,7 @@
 from datetime import date, timedelta, datetime
 
 from django.template.loader import get_template
-from django.template import loader, Context
+from django.template import loader
 from django.core.mail import EmailMessage
 from django.conf import settings # to get admin email addresses
 from django.db.models import Prefetch
@@ -108,10 +108,9 @@ def send_absentee_report(year, month, day):
 
   subject = "Absent Trainee Roster for " + str(d)
   email_template = loader.get_template('absent_trainee_roster/generate_roster.html')
-  context = Context(ctx)
 
   recipients_emails = settings.ABSENTEE_ROSTER_RECIPIENTS
-  email = EmailMessage(subject, email_template.render(context), settings.SERVER_EMAIL, recipients_emails)
+  email = EmailMessage(subject, email_template.render(ctx), settings.SERVER_EMAIL, recipients_emails)
   email.content_subtype ="html"
   pdf_data = generate_pdf(year, month, day)
   email.attach('roster.pdf', pdf_data.content, 'application/pdf')


### PR DESCRIPTION
Absentee Roseter bug #586
TypeError: context must be a dict rather than Context - Addressed 