### PR TITLE
Leave slip submission date

### DIFF
--- a/ap/accounts/management/commands/update_teams.py
+++ b/ap/accounts/management/commands/update_teams.py
@@ -1,0 +1,28 @@
+from django.core.management.base import BaseCommand
+from accounts.models import Trainee, User
+from teams.models import Team
+from django.core.exceptions import ObjectDoesNotExist
+import xlrd
+
+# run from commands folder: ../../../manage.py update_teams
+class Command(BaseCommand):
+	def handle(self, *args, **options):
+		book = xlrd.open_workbook("S18 Attendance Import 03.02.18.xlsx") #Excel workbook is in commands folder
+		sheet = book.sheet_by_index(0)
+		for row_idx in range(1, sheet.nrows):    # Iterate through rows
+			cell_obj_email = sheet.cell(row_idx, 16)  # Get cell object by row, col
+			cell_obj_team = sheet.cell(row_idx, 40)  # Get cell object by row, col
+			cell_email = cell_obj_email.value # Get cell value
+			cell_team = cell_obj_team.value # Get cell value
+			
+			try:
+				tr = Trainee.objects.get(email=cell_email)
+			except ObjectDoesNotExist:
+				print('Person associated with email: [%s] was not found' % cell_email)
+
+			try:
+				te = Team.objects.get(code=cell_team)
+				tr.team = te
+				tr.save()
+			except ObjectDoesNotExist:
+				print('The team [%s] does not exist for: [%s %s]' % (cell_team, tr.firstname, tr.lastname) )

--- a/ap/leaveslips/templates/leaveslips/leaveslip_update.html
+++ b/ap/leaveslips/templates/leaveslips/leaveslip_update.html
@@ -36,6 +36,11 @@
             <b>Did not inform training office</b>        
           {% endif %}
         </div>
+      </br>
+        <div class="row">
+          Date Submitted: 
+          {{ form.instance.submitted }}
+        </div>
       </div>
       <div class="col-md-7 col-xs-12">
         <div id="react-calendar-root"></div>


### PR DESCRIPTION
Could not display the submitted field in the django form because in models, submitted field has auto_now_add=True:
  _submitted = models.DateTimeField(auto_now_add=True)_
Was getting this error when I tried adding 'submitted' to the fields in IndividualSlipForm
_django.core.exceptions.FieldError: 'submitted' cannot be specified for IndividualSlip model form as it is a non-editable field_

Decided to just do what was suggested below:
https://stackoverflow.com/questions/18874169/how-can-i-show-non-editable-field-in-django-form