### PR TITLE
on_delete=models.SET_NULL

### DIFF
--- a/ap/absent_trainee_roster/models.py
+++ b/ap/absent_trainee_roster/models.py
@@ -80,8 +80,8 @@ class Entry(models.Model):
       ('F', 'Fatigue'),
   )
 
-  roster = models.ForeignKey(Roster)
-  absentee = models.ForeignKey(Absentee)
+  roster = models.ForeignKey(Roster, on_delete=models.SET_NULL, null=True)
+  absentee = models.ForeignKey(Absentee, on_delete=models.SET_NULL, null=True)
   reason = models.CharField(max_length=2, choices=ABSENT_REASONS)
   # to be removed, not yet done to minimize model changes mid-term
   coming_to_class = models.BooleanField(default=False)

--- a/ap/accounts/models.py
+++ b/ap/accounts/models.py
@@ -95,10 +95,7 @@ class UserMeta(models.Model):
                                 )
 
   # refers to the user's home address, not their training residence
-  address = models.ForeignKey(Address, null=True,
-                              blank=True,
-                              verbose_name='home address'
-                              )
+  address = models.ForeignKey(Address, blank=True, verbose_name='home address', on_delete=models.SET_NULL, null=True)
 
   college = models.CharField(max_length=50, null=True, blank=True)
   major = models.CharField(max_length=50, null=True, blank=True)
@@ -125,7 +122,7 @@ class UserMeta(models.Model):
   gospel_pref1 = models.CharField(max_length=2, choices=GOSPEL_PREFS, null=True, blank=True)
   gospel_pref2 = models.CharField(max_length=2, choices=GOSPEL_PREFS, null=True, blank=True)
 
-  bunk = models.ForeignKey(Bunk, null=True, blank=True)
+  bunk = models.ForeignKey(Bunk, on_delete=models.SET_NULL, null=True, blank=True)
 
   readOT = models.BooleanField(default=False)
   readNT = models.BooleanField(default=False)
@@ -186,7 +183,7 @@ class User(AbstractBaseUser, PermissionsMixin):
       }
   )
 
-  badge = models.ForeignKey(Badge, blank=True, null=True)
+  badge = models.ForeignKey(Badge, blank=True, on_delete=models.SET_NULL, null=True)
 
   # All user data
   firstname = models.CharField(verbose_name=u'first name', max_length=30)
@@ -269,12 +266,12 @@ class User(AbstractBaseUser, PermissionsMixin):
   date_begin = models.DateField(null=True, blank=True)
   date_end = models.DateField(null=True, blank=True)
 
-  TA = models.ForeignKey('self', related_name='training_assistant', null=True, blank=True)
-  mentor = models.ForeignKey('self', related_name='mentee', null=True, blank=True)
+  TA = models.ForeignKey('self', related_name='training_assistant', null=True, blank=True, on_delete=models.SET_NULL)
+  mentor = models.ForeignKey('self', related_name='mentee', null=True, blank=True, on_delete=models.SET_NULL)
 
   locality = models.ForeignKey(Locality, null=True, blank=True, on_delete=models.SET_NULL)
 
-  team = models.ForeignKey(Team, null=True, blank=True, related_name='members')
+  team = models.ForeignKey(Team, null=True, blank=True, related_name='members', on_delete=models.SET_NULL)
 
   house = models.ForeignKey(House, null=True, blank=True, related_name='residents', on_delete=models.SET_NULL)
 

--- a/ap/announcements/models.py
+++ b/ap/announcements/models.py
@@ -29,7 +29,7 @@ class Announcement(models.Model, RequestMixin):
   type = models.CharField(max_length=5, choices=ANNOUNCE_TYPE, default='CLASS')
 
   date_requested = models.DateTimeField(auto_now_add=True)
-  author = models.ForeignKey(User, null=True)
+  author = models.ForeignKey(User, null=True, on_delete=models.SET_NULL)
   TA_comments = models.TextField(null=True, blank=True)
   trainee_comments = models.TextField(null=True, blank=True)
   is_popup = models.BooleanField(default=False, blank=True)

--- a/ap/aputils/models.py
+++ b/ap/aputils/models.py
@@ -61,7 +61,7 @@ class Address(models.Model):
   address2 = models.CharField(max_length=150, blank=True)
 
   # City foreign key
-  city = models.ForeignKey(City)
+  city = models.ForeignKey(City, on_delete=models.SET_NULL, null=True)
 
   zip_code = models.CharField(null=True, blank=True, max_length=30)
 
@@ -83,7 +83,7 @@ class Address(models.Model):
 
 
 class HomeAddress(Address):
-  trainee = models.ForeignKey('accounts.Trainee')
+  trainee = models.ForeignKey('accounts.Trainee', on_delete=models.SET_NULL, null=True)
 
 
 class Vehicle(models.Model):
@@ -104,7 +104,7 @@ class Vehicle(models.Model):
 
   capacity = models.PositiveSmallIntegerField()
 
-  user = models.ForeignKey('accounts.User', related_name='vehicles', blank=True, null=True)
+  user = models.ForeignKey('accounts.User', related_name='vehicles', blank=True, null=True, on_delete=models.SET_NULL)
 
   def __unicode__(self):
     return ('%s %s %s') % (self.color, self.make, self.model)
@@ -121,7 +121,7 @@ class EmergencyInfo(models.Model):
 
   phone2 = models.CharField(max_length=15, blank=True, null=True)
 
-  address = models.ForeignKey(Address)
+  address = models.ForeignKey(Address, on_delete=models.SET_NULL, null=True)
 
   trainee = models.OneToOneField('accounts.Trainee', blank=True, null=True)
 

--- a/ap/attendance/models.py
+++ b/ap/attendance/models.py
@@ -20,16 +20,16 @@ DATA MODELS:
 class Roll(models.Model):
 
   ROLL_STATUS = (
-    ('P', 'Present'),
-    ('A', 'Absent'),
-    ('T', 'Tardy'),
-    ('U', 'Uniform'),
-    ('L', 'Left Class')
+      ('P', 'Present'),
+      ('A', 'Absent'),
+      ('T', 'Tardy'),
+      ('U', 'Uniform'),
+      ('L', 'Left Class')
   )
 
-  event = models.ForeignKey(Event)
+  event = models.ForeignKey(Event, null=True, on_delete=models.SET_NULL)
 
-  trainee = models.ForeignKey(Trainee, related_name='rolls')
+  trainee = models.ForeignKey(Trainee, null=True, related_name='rolls', on_delete=models.SET_NULL)
 
   status = models.CharField(max_length=1, choices=ROLL_STATUS)
 
@@ -44,7 +44,7 @@ class Roll(models.Model):
   # for second year it can either by a second year trainee and/or any of the roles listed above
   # for second year there can be two roll objects per event, one submitted by the second year trainee and one submitted by a monitor, this is for audits
 
-  submitted_by = models.ForeignKey(User, null=True, related_name='submitted_rolls')
+  submitted_by = models.ForeignKey(User, null=True, related_name='submitted_rolls', on_delete=models.SET_NULL)
 
   # when the roll was last updated
   last_modified = models.DateTimeField(auto_now=True)

--- a/ap/audio/models.py
+++ b/ap/audio/models.py
@@ -160,7 +160,7 @@ class AudioRequest(models.Model, RequestMixin):
   )
   status = models.CharField(max_length=1, choices=AUDIO_STATUS, default='P')
   date_requested = models.DateTimeField(auto_now_add=True)
-  trainee_author = models.ForeignKey(Trainee, null=True)
+  trainee_author = models.ForeignKey(Trainee, on_delete=models.SET_NULL, null=True)
   TA_comments = models.TextField(null=True, blank=True)
   trainee_comments = models.TextField()
   audio_requested = models.ManyToManyField(AudioFile, related_name='audio_requests')

--- a/ap/badges/models.py
+++ b/ap/badges/models.py
@@ -28,7 +28,7 @@ class Badge(models.Model):
 
   type = models.CharField(max_length=2, choices=BADGE_TYPES, default='T')
   original = models.ImageField(upload_to=_image_upload_path, null=True, blank=True)
-  term_created = models.ForeignKey(Term)
+  term_created = models.ForeignKey(Term, on_delete=models.SET_NULL, null=True)
   # thumbnail
   # badge_size
 

--- a/ap/bible_tracker/models.py
+++ b/ap/bible_tracker/models.py
@@ -6,8 +6,9 @@ from verse_parse.bible_re import *
 
 import json
 
+
 class BibleReading(models.Model):
-  trainee = models.ForeignKey(Trainee, null=True)
+  trainee = models.ForeignKey(Trainee, null=True, on_delete=models.SET_NULL)
   weekly_reading_status = HStoreField()
   books_read = HStoreField()
 

--- a/ap/books/models.py
+++ b/ap/books/models.py
@@ -71,10 +71,10 @@ class Book(models.Model):
   chapters = models.SmallIntegerField(blank=True, null=True)
 
   # the collection this book belongs to, if any
-  collection = models.ForeignKey(Collection, blank=True, null=True)
+  collection = models.ForeignKey(Collection, blank=True, null=True, on_delete=models.SET_NULL)
 
   # the book's publisher
-  publisher = models.ForeignKey(Publisher)
+  publisher = models.ForeignKey(Publisher, null=True, on_delete=models.SET_NULL)
 
   def __unicode__(self):
     return self.name

--- a/ap/classnotes/models.py
+++ b/ap/classnotes/models.py
@@ -39,7 +39,7 @@ class Classnotes(models.Model):
   date_due = models.DateTimeField(editable=False)
   date_submitted = models.DateTimeField(blank=True, null=True)
 
-  event = models.ForeignKey(Event, blank=True, null=True)
+  event = models.ForeignKey(Event, blank=True, null=True, on_delete=models.SET_NULL)
 
   # minWord Count
   minimum_words = models.PositiveSmallIntegerField(default=250)
@@ -47,7 +47,7 @@ class Classnotes(models.Model):
 
   status = models.CharField(max_length=1, choices=CN_STATUS, default='U')
   type = models.CharField(max_length=1, choices=CN_TYPE, default='R')
-  trainee = models.ForeignKey(Trainee, related_name='%(class)ss')
+  trainee = models.ForeignKey(Trainee, related_name='%(class)ss', on_delete=models.SET_NULL, null=True)
 
   def add_comments(self, comments):
     self.comments = comments

--- a/ap/dailybread/models.py
+++ b/ap/dailybread/models.py
@@ -17,7 +17,7 @@ class Portion(models.Model):
   title = models.CharField(max_length=255)
   text = models.TextField()
   ref = models.CharField(max_length=255)
-  submitted_by = models.ForeignKey(User)
+  submitted_by = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
   timestamp = models.TimeField(auto_now_add=True)
   approved = models.BooleanField(default=False)
 

--- a/ap/exams/models.py
+++ b/ap/exams/models.py
@@ -31,10 +31,10 @@ DATA MODELS:
 
 
 class Exam(models.Model):
-  training_class = models.ForeignKey(Class)
+  training_class = models.ForeignKey(Class, on_delete=models.SET_NULL, null=True)
   description = models.CharField(max_length=250, blank=True)
   is_open = models.BooleanField(default=False)
-  term = models.ForeignKey(Term, null=True)
+  term = models.ForeignKey(Term, null=True, on_delete=models.SET_NULL)
   duration = models.DurationField(default=timedelta(minutes=90))
 
   # does this exam contribute to the midterm grade or to the final grade?
@@ -98,7 +98,7 @@ class Exam(models.Model):
 
 
 class Section(models.Model):
-  exam = models.ForeignKey(Exam, related_name='sections')
+  exam = models.ForeignKey(Exam, related_name='sections', on_delete=models.SET_NULL, null=True)
   SECTION_CHOICES = (('MC', 'Multiple Choice'),
                      ('E', 'Essay'),
                      ('M', 'Matching'),
@@ -172,8 +172,8 @@ class Section(models.Model):
 
 
 class Session(models.Model):
-  trainee = models.ForeignKey(Trainee, related_name='exam_sessions')
-  exam = models.ForeignKey(Exam, related_name='sessions')
+  trainee = models.ForeignKey(Trainee, related_name='exam_sessions', null=True, on_delete=models.SET_NULL)
+  exam = models.ForeignKey(Exam, related_name='sessions', on_delete=models.SET_NULL, null=True)
 
   is_submitted_online = models.BooleanField(default=True)
   is_graded = models.BooleanField(default=False)
@@ -189,8 +189,8 @@ class Session(models.Model):
 
 
 class Responses(models.Model):
-  session = models.ForeignKey(Session, related_name='responses')
-  section = models.ForeignKey(Section, related_name='responses')
+  session = models.ForeignKey(Session, related_name='responses', on_delete=models.SET_NULL, null=True)
+  section = models.ForeignKey(Section, related_name='responses', on_delete=models.SET_NULL, null=True)
 
   responses = HStoreField(null=True)
   score = models.DecimalField(max_digits=5, decimal_places=2)
@@ -202,6 +202,6 @@ class Responses(models.Model):
 
 # Makeup are deleted upon creation of session.
 class Makeup(models.Model):
-  trainee = models.ForeignKey(Trainee, related_name='exam_makeup')
-  exam = models.ForeignKey(Exam)
+  trainee = models.ForeignKey(Trainee, related_name='exam_makeup', on_delete=models.SET_NULL, null=True)
+  exam = models.ForeignKey(Exam, on_delete=models.SET_NULL, null=True)
   time_opened = models.DateTimeField(auto_now_add=True)

--- a/ap/graduation/models.py
+++ b/ap/graduation/models.py
@@ -82,10 +82,10 @@ class Survey(models.Model):
   )
 
   # grad admin controls the survey
-  grad_admin = models.ForeignKey(GradAdmin)
+  grad_admin = models.ForeignKey(GradAdmin, null=True, on_delete=models.SET_NULL)
 
   # trainee filling out the survey
-  trainee = models.ForeignKey(Trainee)
+  trainee = models.ForeignKey(Trainee, null=True, on_delete=models.SET_NULL)
 
   @property
   def name(self):

--- a/ap/graduation/urls.py
+++ b/ap/graduation/urls.py
@@ -12,8 +12,7 @@ urlpatterns = [
     url(r'misc$', views.MiscView.as_view(), name='misc-view'),
     url(r'misc_report$', views.MiscReport.as_view(), name='misc-report'),
     url(r'testimony_report$', views.TestimonyReport.as_view(), name='testimony-report'),
-    url(r'consederation_report$', views.ConsiderationReport.as_view(), name='consideration-report'),
+    url(r'consideration_report$', views.ConsiderationReport.as_view(), name='consideration-report'),
     url(r'website_report$', views.WebsiteReport.as_view(), name='website-report'),
     url(r'outline_report$', views.OutlineReport.as_view(), name='outline-report'),
-
 ]

--- a/ap/graduation/views.py
+++ b/ap/graduation/views.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from django.views.generic.edit import UpdateView
 from django.views.generic import ListView
 from django.db.models import Sum
+from django.template.defaultfilters import title
 
 from terms.models import Term
 from graduation.models import *
@@ -125,8 +126,8 @@ class ReportView(ListView):
     objs = self.model.objects.all()
     o = [o for o in objs if o.responded]
     context.update({
-      'data': o,
-      'title': self.model + ' Report'
+        'data': o,
+        'title': title(self.model._meta.verbose_name + ' Report'),
     })
 
 

--- a/ap/hc/models.py
+++ b/ap/hc/models.py
@@ -3,13 +3,12 @@ from houses.models import House
 from accounts.models import Trainee
 from terms.models import Term
 from django.core.urlresolvers import reverse
-from datetime import datetime
 
 
 class HCSurveyAdmin(models.Model):
 
   # keeps track of term
-  term = models.ForeignKey(Term, null=True, blank=True)
+  term = models.ForeignKey(Term, null=True, blank=True, on_delete=models.SET_NULL)
 
   # 1st, 2nd, 3rd (etc.) survey of the term
   index = models.SmallIntegerField(default=0)
@@ -29,7 +28,7 @@ class HCSurveyAdmin(models.Model):
 
 class HCRecommendationAdmin(models.Model):
 
-  term = models.ForeignKey(Term, null=True, blank=True)
+  term = models.ForeignKey(Term, null=True, blank=True, on_delete=models.SET_NULL)
 
   open_survey = models.BooleanField(default=False)
 
@@ -40,13 +39,13 @@ class HCRecommendationAdmin(models.Model):
 
 class HCSurvey(models.Model):
 
-  survey_admin = models.ForeignKey(HCSurveyAdmin, null=True, blank=True)
+  survey_admin = models.ForeignKey(HCSurveyAdmin, null=True, blank=True, on_delete=models.SET_NULL)
 
   # many-to-one: The house (has many surveys) this survey concerns
-  house = models.ForeignKey(House, null=True)
+  house = models.ForeignKey(House, null=True, on_delete=models.SET_NULL)
 
   # hc submitting the HCSurvey
-  hc = models.ForeignKey(Trainee, null=True)
+  hc = models.ForeignKey(Trainee, null=True, on_delete=models.SET_NULL)
 
   # atmosphere of the house
   atmosphere = models.TextField(blank=True, null=True)
@@ -64,10 +63,10 @@ class HCSurvey(models.Model):
 class HCTraineeComment(models.Model):
 
   # the corresponding HC Survey
-  hc_survey = models.ForeignKey(HCSurvey, null=True)
+  hc_survey = models.ForeignKey(HCSurvey, null=True, on_delete=models.SET_NULL)
 
   # the (resident) trainee this comment concerns
-  trainee = models.ForeignKey(Trainee, null=True)
+  trainee = models.ForeignKey(Trainee, null=True, on_delete=models.SET_NULL)
 
   # the comment concerning the trainee
   assessment = models.TextField(blank=True, null=True)
@@ -78,16 +77,16 @@ class HCTraineeComment(models.Model):
 
 class HCRecommendation(models.Model):
 
-  survey_admin = models.ForeignKey(HCRecommendationAdmin, null=True, blank=True)
+  survey_admin = models.ForeignKey(HCRecommendationAdmin, null=True, blank=True, on_delete=models.SET_NULL)
 
   # The recommendation concerning this house
-  house = models.ForeignKey(House, null=True)
+  house = models.ForeignKey(House, null=True, on_delete=models.SET_NULL)
 
   # hc writing this recommendation
-  hc = models.ForeignKey(Trainee, related_name='hc', null=True)
+  hc = models.ForeignKey(Trainee, related_name='hc', null=True, on_delete=models.SET_NULL)
 
   # trainee recommended by hc for hc role
-  recommended_hc = models.ForeignKey(Trainee, related_name='recommended_hc', null=True)
+  recommended_hc = models.ForeignKey(Trainee, related_name='recommended_hc', null=True, on_delete=models.SET_NULL)
 
   # choice - yes or no
   CHOICE = (('YES', 'yes'), ('NO', 'no'))

--- a/ap/hospitality/models.py
+++ b/ap/hospitality/models.py
@@ -2,14 +2,16 @@ from django.db import models
 from accounts.models import User
 from houses.models import House, Bunk
 
+
 """  hospitality models.py
 This module takes care of all the logistics of LSM hospitality.
-
 """
+
 
 class HospitalityGuest(User):
 
   visits = models.ManyToManyField('Visit')
+
 
 class Visit(models.Model):
   """ a single stay with LSM hospitality """
@@ -22,6 +24,6 @@ class Visit(models.Model):
 
   departureDate = models.DateField()
 
-  house = models.ForeignKey(House)
+  house = models.ForeignKey(House, on_delete=models.SET_NULL, null=True)
 
-  bunk = models.ForeignKey(Bunk)
+  bunk = models.ForeignKey(Bunk, on_delete=models.SET_NULL, null=True)

--- a/ap/house_requests/models.py
+++ b/ap/house_requests/models.py
@@ -18,9 +18,9 @@ class HouseRequest(models.Model, RequestMixin):
 
   status = models.CharField(max_length=1, choices=STATUS, default='P')
   date_requested = models.DateTimeField(auto_now_add=True)
-  trainee_author = models.ForeignKey(User, null=True)
+  trainee_author = models.ForeignKey(User, null=True, on_delete=models.SET_NULL)
   TA_comments = models.TextField(null=True, blank=True)
-  house = models.ForeignKey(House)
+  house = models.ForeignKey(House, on_delete=models.SET_NULL, null=True)
 
   def get_category(self):
     return self.type + ' - ' + str(self.house)
@@ -47,7 +47,7 @@ class MaintenanceRequest(HouseRequest, models.Model):
   type = 'Maintenance'
   description = models.TextField()
   urgent = models.BooleanField(default=False)
-  room = models.ForeignKey(Room, null=True, blank=True)
+  room = models.ForeignKey(Room, null=True, blank=True, on_delete=models.SET_NULL)
 
   request_types = (
       ('AIR', 'Air - Includes issues related to air conditioning, air filters, condensation, heating, thermostats, and ventilation.'),

--- a/ap/houses/models.py
+++ b/ap/houses/models.py
@@ -43,7 +43,7 @@ class House(models.Model):
   name = models.CharField(max_length=50)
 
   # the house's address (defined in the utils class)
-  address = models.ForeignKey(Address)
+  address = models.ForeignKey(Address, on_delete=models.SET_NULL, null=True)
 
   # a house can designated for either brothers, sisters, or a couple
   gender = models.CharField(max_length=1, choices=GENDER)
@@ -103,7 +103,7 @@ class Room(models.Model):
   # refers to number of beds
   capacity = models.SmallIntegerField(default=0)  # 0 if room is not a bedroom
 
-  house = models.ForeignKey(House)
+  house = models.ForeignKey(House, on_delete=models.SET_NULL, null=True)
 
   floor = models.SmallIntegerField(default=1)
 
@@ -146,7 +146,7 @@ class Bunk(models.Model):
   link = models.OneToOneField('Bunk', null=True, blank=True)
 
   # which room this bunk is in
-  room = models.ForeignKey(Room)
+  room = models.ForeignKey(Room, on_delete=models.SET_NULL, null=True)
 
   length = models.CharField(max_length=1, choices=LENGTH, default='R')
 

--- a/ap/leaveslips/models.py
+++ b/ap/leaveslips/models.py
@@ -64,12 +64,12 @@ class LeaveSlip(models.Model, RequestMixin):
   status = models.CharField(max_length=1, choices=LS_STATUS, default='P')
 
   # TA Assigned to this leave slip
-  TA = models.ForeignKey(TrainingAssistant, blank=True, null=True, related_name="%(class)sslips")
+  TA = models.ForeignKey(TrainingAssistant, blank=True, null=True, related_name="%(class)sslips", on_delete=models.SET_NULL)
 
   # TA informed
-  TA_informed = models.ForeignKey(TrainingAssistant, blank=True, null=True, related_name="%(class)sslips_informed")
+  TA_informed = models.ForeignKey(TrainingAssistant, blank=True, null=True, related_name="%(class)sslips_informed", on_delete=models.SET_NULL)
 
-  trainee = models.ForeignKey(Trainee, related_name='%(class)ss')  # trainee who submitted the leave slip
+  trainee = models.ForeignKey(Trainee, related_name='%(class)ss', on_delete=models.SET_NULL, null=True)  # trainee who submitted the leave slip
 
   submitted = models.DateTimeField(auto_now_add=True)
   last_modified = models.DateTimeField(auto_now=True)
@@ -222,7 +222,7 @@ class GroupSlip(LeaveSlip):
   end = models.DateTimeField()
   trainees = models.ManyToManyField(Trainee, related_name='groupslip')  # trainees included in the leave slip
   # Field to relate GroupSlips to Service Assignments
-  service_assignment = models.ForeignKey(Assignment, blank=True, null=True, verbose_name="Service")
+  service_assignment = models.ForeignKey(Assignment, blank=True, null=True, verbose_name="Service", on_delete=models.SET_NULL)
 
   def get_date(self):
     return self.start.date()

--- a/ap/lifestudies/models.py
+++ b/ap/lifestudies/models.py
@@ -64,7 +64,7 @@ class Discipline(models.Model):
   # the type of offense being assigned
   offense = models.CharField(choices=TYPE_OFFENSE_CHOICES, default='RO', max_length=2)
 
-  trainee = models.ForeignKey(User)
+  trainee = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
 
   missed_service = models.TextField(blank=True, null=True)
 
@@ -171,7 +171,7 @@ class Summary(models.Model):
 
   # the book assigned to summary
   # relationship: many summaries to one book
-  book = models.ForeignKey(Book, null=True, blank=True)
+  book = models.ForeignKey(Book, null=True, blank=True, on_delete=models.SET_NULL)
 
   # the chapter assigned to summary
   chapter = models.PositiveSmallIntegerField()
@@ -187,7 +187,7 @@ class Summary(models.Model):
   #deleted = models.BooleanField(default=False)
 
   # which discipline this summary is associated with
-  discipline = models.ForeignKey(Discipline)
+  discipline = models.ForeignKey(Discipline, on_delete=models.SET_NULL, null=True)
 
   # automatically generated date when summary is submitted
   date_submitted = models.DateTimeField(auto_now_add=True)

--- a/ap/localities/models.py
+++ b/ap/localities/models.py
@@ -16,7 +16,7 @@ Data Models:
 
 class Locality(models.Model):
 
-  city = models.ForeignKey(City)
+  city = models.ForeignKey(City, on_delete=models.SET_NULL, null=True)
 
   def __unicode__(self):
     return self.city.name + ", " + str(self.city.state)

--- a/ap/room_reservations/models.py
+++ b/ap/room_reservations/models.py
@@ -33,7 +33,7 @@ class RoomReservation(models.Model, RequestMixin):
       ('Term', 'reserve for the entire term'),
   )
 
-  requester = models.ForeignKey(User)
+  requester = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
 
   # time of submission
   submitted = models.DateTimeField(auto_now_add=True)
@@ -57,7 +57,7 @@ class RoomReservation(models.Model, RequestMixin):
   end = models.TimeField()
 
   # room being requested
-  room = models.ForeignKey(Room)
+  room = models.ForeignKey(Room, on_delete=models.SET_NULL, null=True)
 
   # size of group
   group_size = models.IntegerField(default=10)

--- a/ap/schedules/models.py
+++ b/ap/schedules/models.py
@@ -96,7 +96,7 @@ class Event(models.Model):
 
   # Reference to Chart
   # Optional field, not all Events have seating chart
-  chart = models.ForeignKey(Chart, blank=True, null=True)
+  chart = models.ForeignKey(Chart, blank=True, null=True, on_delete=models.SET_NULL)
 
   # Unifies the way to get weekday from events with self.day or self.weekday
   def get_uniform_weekday(self):
@@ -206,7 +206,7 @@ class Schedule(models.Model):
   trainee_select = models.CharField(max_length=2, choices=TRAINEE_FILTER, default='MC')
 
   # Choose which team roll this schedule shows up on
-  team_roll = models.ForeignKey(Team, related_name='schedules', blank=True, null=True)
+  team_roll = models.ForeignKey(Team, related_name='schedules', blank=True, null=True, on_delete=models.SET_NULL)
 
   date_created = models.DateTimeField(auto_now=True)
 
@@ -216,7 +216,7 @@ class Schedule(models.Model):
   # Parent schedule points to a full-term version of the most-recent schedule, which can be
   # easily imported to the next term.
   # This is to keep historical data intact. See assign_trainees_to_schedule method
-  parent_schedule = models.ForeignKey('self', related_name='parent', null=True, blank=True)
+  parent_schedule = models.ForeignKey('self', related_name='parent', null=True, blank=True, on_delete=models.SET_NULL)
 
   # Is this already a parent schedule this term?
   is_parent_schedule = models.BooleanField(default=False)
@@ -233,9 +233,9 @@ class Schedule(models.Model):
   # is_locked flag
   is_locked = models.BooleanField(default=False)
 
-  term = models.ForeignKey(Term, null=True, blank=True)
+  term = models.ForeignKey(Term, null=True, blank=True, on_delete=models.SET_NULL)
 
-  query_filter = models.ForeignKey(QueryFilter, null=True, blank=True)
+  query_filter = models.ForeignKey(QueryFilter, null=True, blank=True, on_delete=models.SET_NULL)
 
   # Hides "deleted" schedule but keeps it for the sake of record
   is_deleted = models.BooleanField(default=False)

--- a/ap/seating/models.py
+++ b/ap/seating/models.py
@@ -33,7 +33,7 @@ class Chart(models.Model):
   name = models.CharField(max_length=100)
   desc = models.CharField(max_length=255, null=True, blank=True)
 
-  term = models.ForeignKey(Term)
+  term = models.ForeignKey(Term, on_delete=models.SET_NULL, null=True)
 
   height = models.PositiveSmallIntegerField()
   width = models.PositiveSmallIntegerField()
@@ -46,8 +46,8 @@ class Chart(models.Model):
 
 class Seat(models.Model):
   """ Intermediate model to relate a Trainee to a seating Chart """
-  trainee = models.ForeignKey(Trainee)
-  chart = models.ForeignKey(Chart)
+  trainee = models.ForeignKey(Trainee, null=True, on_delete=models.SET_NULL)
+  chart = models.ForeignKey(Chart, on_delete=models.SET_NULL, null=True)
 
   # coordinates
   x = models.PositiveSmallIntegerField()
@@ -59,7 +59,7 @@ class Seat(models.Model):
 
 class Partial(models.Model):
   """ Defines a subset of a seating chart. Mainly used for entering roll """
-  chart = models.ForeignKey(Chart)
+  chart = models.ForeignKey(Chart, on_delete=models.SET_NULL, null=True)
 
   """ Section name eg. A, B... """
   section_name = models.CharField(max_length=5)

--- a/ap/services/models/assignment.py
+++ b/ap/services/models/assignment.py
@@ -7,16 +7,17 @@ from datetime import datetime, timedelta
 Service swap -> check qualification mismatch but maybe lax on schedule conflict exception checking
 '''
 
+
 class Assignment(models.Model):
   """
   Defines a relationship between a worker and a service instance
   """
 
-  week_schedule = models.ForeignKey('WeekSchedule', related_name='assignments', blank=True)
+  week_schedule = models.ForeignKey('WeekSchedule', related_name='assignments', blank=True, on_delete=models.SET_NULL, null=True)
 
-  service = models.ForeignKey('Service', related_name='assignments')
+  service = models.ForeignKey('Service', related_name='assignments', null=True, on_delete=models.SET_NULL)
   # Get role + workload
-  service_slot = models.ForeignKey('ServiceSlot', related_name='assignments', default=None)
+  service_slot = models.ForeignKey('ServiceSlot', related_name='assignments', default=None, null=True, on_delete=models.SET_NULL)
 
   workers = models.ManyToManyField('Worker', related_name="assignments", blank=True)
 

--- a/ap/services/models/exception.py
+++ b/ap/services/models/exception.py
@@ -17,7 +17,10 @@ class ServiceException(models.Model):
   desc = models.CharField(max_length=255, null=True, blank=True)
 
   # Tag allows for custom filtering and tagging of big exception data set
-  tag = models.CharField(max_length=255, null=True, blank=True, help_text='Tags allows for custom filtering and tagging of big exception data set')
+  tag = models.CharField(
+      max_length=255, null=True, blank=True,
+      help_text='Tags allows for custom filtering and tagging of big exception data set'
+  )
 
   start = models.DateField()
   # some exceptions are just evergreen
@@ -30,12 +33,18 @@ class ServiceException(models.Model):
   workers = models.ManyToManyField('Worker', related_name="exceptions")
   services = models.ManyToManyField('Service', related_name='exceptions', verbose_name='service exceptions')
   # If none chosen, apply to all schedules by default
-  schedule = models.ForeignKey('SeasonalServiceSchedule', related_name='exceptions', null=True, blank=True, verbose_name='Restrict to schedule (leave blank to apply to all)')
+  schedule = models.ForeignKey(
+      'SeasonalServiceSchedule',
+      related_name='exceptions',
+      null=True, blank=True,
+      verbose_name='Restrict to schedule (leave blank to apply to all)',
+      on_delete=models.SET_NULL
+  )
 
   workload = models.PositiveSmallIntegerField(default=0)
 
   # Designated service
-  service = models.ForeignKey('Service', related_name='service_exceptions', null=True, blank=True, verbose_name='designated service exception', help_text='Some exceptions might be related to a designated service. (Eg. transportation)')
+  service = models.ForeignKey('Service', related_name='service_exceptions', null=True, blank=True, verbose_name='designated service exception', help_text='Some exceptions might be related to a designated service. (Eg. transportation)', on_delete=models.SET_NULL)
 
   last_modified = models.DateTimeField(auto_now=True)
 

--- a/ap/services/models/service.py
+++ b/ap/services/models/service.py
@@ -42,7 +42,7 @@ class Service(models.Model):
 
   # Category groups all the individual services into one group for editting
   # e.g. Monday Breakfast Cleanup, Tuesday Breakfast Cleanup
-  category = models.ForeignKey('Category', related_name="services")
+  category = models.ForeignKey('Category', related_name="services", on_delete=models.SET_NULL, null=True)
   schedule = models.ManyToManyField('SeasonalServiceSchedule', related_name="services")
 
   active = models.BooleanField(default=True)
@@ -129,8 +129,8 @@ WorkerGroup: 1st term stars
 
 class ServiceSlot(models.Model):
   name = models.CharField(max_length=100)
-  service = models.ForeignKey('Service')
-  worker_group = models.ForeignKey('WorkerGroup')
+  service = models.ForeignKey('Service', null=True, on_delete=models.SET_NULL)
+  worker_group = models.ForeignKey('WorkerGroup', null=True, on_delete=models.SET_NULL)
   workers_required = models.PositiveSmallIntegerField(default=1)
   # on a scale of 1-12, with 12 being the most intense (workload
   # is potentially different for different roles depending within same service)
@@ -160,7 +160,7 @@ class ServiceSlot(models.Model):
 
 # Stores history of graph json so assign algo doesn't have to be rerun to modify the graph
 class GraphJson(models.Model):
-  week_schedule = models.ForeignKey('WeekSchedule', related_name='graphs')
+  week_schedule = models.ForeignKey('WeekSchedule', related_name='graphs', null=True, on_delete=models.SET_NULL)
   json = models.TextField()
 
   status = models.CharField(max_length=100)

--- a/ap/services/models/service_hours.py
+++ b/ap/services/models/service_hours.py
@@ -18,11 +18,11 @@ CHOICES = [(i, i) for i in range(20)]
 
 class ServiceAttendance(models.Model):
 
-  worker = models.ForeignKey(Worker, blank=True)  # change to worker
+  worker = models.ForeignKey(Worker, blank=True, on_delete=models.SET_NULL, null=True)
 
-  designated_service = models.ForeignKey(Service)
+  designated_service = models.ForeignKey(Service, null=True, on_delete=models.SET_NULL)
 
-  term = models.ForeignKey(Term, blank=True)
+  term = models.ForeignKey(Term, blank=True, on_delete=models.SET_NULL, null=True)
 
   week = models.IntegerField(default=0, choices=CHOICES)
 
@@ -32,7 +32,7 @@ class ServiceAttendance(models.Model):
 
 class ServiceRoll(models.Model):
 
-  service_attendance = models.ForeignKey(ServiceAttendance, blank=True)
+  service_attendance = models.ForeignKey(ServiceAttendance, blank=True, on_delete=models.SET_NULL, null=True)
 
   start_datetime = models.DateTimeField(null=True, blank=True)
 

--- a/ap/services/models/week_schedule.py
+++ b/ap/services/models/week_schedule.py
@@ -49,7 +49,7 @@ class WeekSchedule(models.Model):
     return self.avg_workload + self.workload_margin
 
   ## Info on scheduler who created the schedule and info on last modified
-  scheduler = models.ForeignKey('accounts.Trainee')
+  scheduler = models.ForeignKey('accounts.Trainee', on_delete=models.SET_NULL, null=True)
   last_modified = models.DateTimeField(auto_now=True)
 
   @staticmethod

--- a/ap/shortterm/models.py
+++ b/ap/shortterm/models.py
@@ -15,23 +15,23 @@ class ShortTermTrainee(User):
 class Visit(models.Model):
   """ a single short-term visit """
 
-  application = models.ForeignKey('Application')
+  application = models.ForeignKey('Application', on_delete=models.SET_NULL, null=True)
 
-  term = models.ForeignKey(Term)
+  term = models.ForeignKey(Term, on_delete=models.SET_NULL, null=True)
 
   arrivalDate = models.DateField()
 
   departureDate = models.DateField()
 
-  mentor = models.ForeignKey(Trainee)
+  mentor = models.ForeignKey(Trainee, on_delete=models.SET_NULL, null=True)
 
-  house = models.ForeignKey(House)
+  house = models.ForeignKey(House, on_delete=models.SET_NULL, null=True)
 
-  bunk = models.ForeignKey(Bunk)
+  bunk = models.ForeignKey(Bunk, on_delete=models.SET_NULL, null=True)
 
 class Application(models.Model):
   """ an application to short term at the FTTA """
 
-  locality = models.ForeignKey(Locality)
+  locality = models.ForeignKey(Locality, on_delete=models.SET_NULL, null=True)
 
   recommendation = models.TextField()

--- a/ap/syllabus/models.py
+++ b/ap/syllabus/models.py
@@ -31,7 +31,7 @@ Data Models:
 class Syllabus (models.Model):
 
   # which class this syllabus belongs to
-  class_syllabus = models.ForeignKey(Class)
+  class_syllabus = models.ForeignKey(Class, on_delete=models.SET_NULL, null=True)
 
   # whether assignment is read before or after class (== true)
   after = models.BooleanField(default=False)
@@ -80,7 +80,7 @@ class ClassSession(models.Model):
   # book name, code
   """ TO DO: Make this OPTIONAL. """
   """and make this multiple"""
-  book = models.ForeignKey(Book) #, blank=True, null=True)
+  book = models.ForeignKey(Book, on_delete=models.SET_NULL, null=True)
 
   # assignment info (pages; chapters; msgs; lessons; verses; exam: "FINAL, MIDTERM, ETC")
     # can list multiple assigments, e.g. memory verses
@@ -90,7 +90,7 @@ class ClassSession(models.Model):
   exam = models.BooleanField(default=False)
 
   # the class syllabus this session refers to
-  syllabus = models.ForeignKey(Syllabus)
+  syllabus = models.ForeignKey(Syllabus, on_delete=models.SET_NULL, null=True)
 
   def __unicode__(self):
     return (self.syllabus.class_syllabus.name + " | "

--- a/ap/teams/models.py
+++ b/ap/teams/models.py
@@ -31,10 +31,10 @@ class Team(models.Model):
   type = models.CharField(max_length=6, choices=TEAM_TYPES)
 
   # which locality this team is in
-  locality = models.ForeignKey(Locality)
+  locality = models.ForeignKey(Locality, on_delete=models.SET_NULL, null=True)
 
   # opposite of subteam... relates subteams to their superteam
-  superteam = models.ForeignKey('self', blank=True, null=True)
+  superteam = models.ForeignKey('self', blank=True, null=True, on_delete=models.SET_NULL)
 
   def __unicode__(self):
     return self.name

--- a/ap/verse_parse/models.py
+++ b/ap/verse_parse/models.py
@@ -13,7 +13,7 @@ class OutlinePoint(models.Model):
 
 
 class Reference(models.Model):
-  outline_point = models.ForeignKey(OutlinePoint)
+  outline_point = models.ForeignKey(OutlinePoint, on_delete=models.SET_NULL, null=True)
   book = models.CharField(max_length=25)
   chapter = models.PositiveSmallIntegerField(null=True)
   verse = models.PositiveSmallIntegerField(null=True)

--- a/ap/web_access/models.py
+++ b/ap/web_access/models.py
@@ -54,7 +54,7 @@ class WebRequest(models.Model, RequestMixin):
   time_started = models.DateTimeField(auto_now_add=False, blank=True, null=True)
   date_expire = models.DateField()
   mac_address = models.CharField(blank=True, null=True, max_length=60)
-  trainee = models.ForeignKey(Trainee, blank=True, null=True)
+  trainee = models.ForeignKey(Trainee, blank=True, null=True, on_delete=models.SET_NULL)
   comments = models.TextField()
   TA_comments = models.TextField(blank=True, null=True)
   urgent = models.BooleanField(default=False)


### PR DESCRIPTION
fixes #920
fixes #929

and all other similar potential issues.

The `on_delete` keyword is required starting Django 2.0 anyway so we'd have to add it when we want to upgrade. Doing this may leave a bunch of things around later but at least we're safe from accidentally deleting stuff?