### PR TITLE
Leaveslip ta view fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: pip
 python:
 - 2.7
 addons:
-  postgresql: '9.3'
+  postgresql: '9.6'
 env:
   - DJANGO_SETTINGS_MODULE=ap.settings.travis
 install:

--- a/ap/accounts/models.py
+++ b/ap/accounts/models.py
@@ -521,14 +521,14 @@ class TrainingAssistant(User):
   inactive = InactiveTAManager()
 
 
+def default_settings():
+  return {"leaveslip":{"selected_ta":-1, "selected_status":"P"}}
+
 # Statistics / records on trainee (e.g. attendance, absences, service/fatigue level, preferences, etc)
 class Statistics(models.Model):
   trainee = models.OneToOneField(User, related_name='statistics', null=True, blank=True)
 
   # String containing book name + last chapter of lifestudy written ([book_id]:[chapter], Genesis:3)
   latest_ls_chpt = models.CharField(max_length=400, null=True, blank=True)
-
-  def default_settings():
-    return {"leaveslip":{"selected_ta":-1, "selected_status":"P"}}
 
   settings = JSONField(default=default_settings())

--- a/ap/accounts/models.py
+++ b/ap/accounts/models.py
@@ -5,6 +5,7 @@ import dateutil
 from django.db import models
 from django.db.models import Q
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin, Group
+from django.contrib.postgres.fields import JSONField
 from django.core.mail import send_mail
 from django.core import validators
 from django.utils.http import urlquote
@@ -526,3 +527,8 @@ class Statistics(models.Model):
 
   # String containing book name + last chapter of lifestudy written ([book_id]:[chapter], Genesis:3)
   latest_ls_chpt = models.CharField(max_length=400, null=True, blank=True)
+
+  def default_settings():
+    return {"leaveslip":{"selected_ta":-1, "selected_status":"P"}}
+
+  settings = JSONField(default=default_settings())

--- a/ap/accounts/models.py
+++ b/ap/accounts/models.py
@@ -522,7 +522,8 @@ class TrainingAssistant(User):
 
 
 def default_settings():
-  return {"leaveslip":{"selected_ta":-1, "selected_status":"P"}}
+  return {"leaveslip": {"selected_ta": -1, "selected_status": "P"}}
+
 
 # Statistics / records on trainee (e.g. attendance, absences, service/fatigue level, preferences, etc)
 class Statistics(models.Model):

--- a/ap/ap/settings/prod.py
+++ b/ap/ap/settings/prod.py
@@ -36,7 +36,7 @@ import dj_database_url
   For the following to work, you need to:
   export DATABASE_URL='postgres://{{username}}:{{password}}@localhost:5432/{{database}}'
 '''
-DATABASES = {'default' : dj_database_url.config()}
+DATABASES = {'default': dj_database_url.config()}
 
 assert 'SECRET_KEY' in os.environ, 'Set SECRET_KEY in your .env file!'
 SECRET_KEY = os.environ['SECRET_KEY']

--- a/ap/aputils/templatetags/smart_cards.py
+++ b/ap/aputils/templatetags/smart_cards.py
@@ -62,8 +62,8 @@ def generate_cards(context):
     TA_leaveslips = Card(
         header_title="Leave Slips",
         card_links=[
-            CardLink(title="Pending", url=reverse('leaveslips:ta-leaveslip-list'), number=ls_p),
-            CardLink(title="Marked for fellowship", url=reverse('leaveslips:ta-leaveslip-list'), number=ls_f),
+            CardLink(title="Pending", url="%s?status=P"%reverse('leaveslips:ta-leaveslip-list'), number=ls_p),
+            CardLink(title="Marked for fellowship", url="%s?status=F"%reverse('leaveslips:ta-leaveslip-list'), number=ls_f),
         ]
     )
 

--- a/ap/aputils/templatetags/smart_cards.py
+++ b/ap/aputils/templatetags/smart_cards.py
@@ -62,8 +62,8 @@ def generate_cards(context):
     TA_leaveslips = Card(
         header_title="Leave Slips",
         card_links=[
-            CardLink(title="Pending", url="%s?status=P"%reverse('leaveslips:ta-leaveslip-list'), number=ls_p),
-            CardLink(title="Marked for fellowship", url="%s?status=F"%reverse('leaveslips:ta-leaveslip-list'), number=ls_f),
+            CardLink(title="Pending", url="%s?status=P&ta=%s"%(reverse('leaveslips:ta-leaveslip-list'), user.id), number=ls_p),
+            CardLink(title="Marked for fellowship", url="%s?status=F&ta=%s"%(reverse('leaveslips:ta-leaveslip-list'), user.id), number=ls_f),
         ]
     )
 

--- a/ap/aputils/templatetags/smart_cards.py
+++ b/ap/aputils/templatetags/smart_cards.py
@@ -12,13 +12,17 @@ from leaveslips.models import IndividualSlip, GroupSlip
 from lifestudies.models import Summary
 from classnotes.models import Classnotes
 
+
 def CardLink(title, url='#', number=None, ta_number=None):
   return namedtuple('CardLink', 'title url number ta_number')(title=title, url=url, number=number, ta_number=ta_number)
+
 
 def Card(header_title, condition=True, card_links=[]):
   return namedtuple('Card', 'header_title condition card_links')(header_title=header_title, condition=condition, card_links=card_links)
 
+
 register = template.Library()
+
 
 # Generates all the cards
 @register.assignment_tag(takes_context=True)
@@ -31,7 +35,7 @@ def generate_cards(context):
 
   if user.has_group(['training_assistant']):
 
-    #filter for trainees assigned to current TA and cross it with existing web requests
+    # filter for trainees assigned to current TA and cross it with existing web requests
     my_trainees = Trainee.objects.filter(TA=user)
 
     web_access_count = WebRequest.objects.filter(status='P').count()
@@ -47,10 +51,10 @@ def generate_cards(context):
     TA_requests = Card(
         header_title="Requests",
         card_links=[
-          CardLink(title="Web Access", url=reverse('web_access:web_access-list'), number=web_access_count, ta_number=web_access_ta_count),
-          CardLink(title="AV", url=reverse('audio:ta-audio-home'), number=av_count, ta_number=av_ta_count),
-          CardLink(title="Room Reservation", url=reverse('room_reservations:ta-room-reservation-list'),number=room_reservation_count),
-          CardLink(title="Announcements", url=reverse('announcements:announcement-request-list'), number=announce_count)
+            CardLink(title="Web Access", url=reverse('web_access:web_access-list'), number=web_access_count, ta_number=web_access_ta_count),
+            CardLink(title="AV", url=reverse('audio:ta-audio-home'), number=av_count, ta_number=av_ta_count),
+            CardLink(title="Room Reservation", url=reverse('room_reservations:ta-room-reservation-list'),number=room_reservation_count),
+            CardLink(title="Announcements", url=reverse('announcements:announcement-request-list'), number=announce_count)
         ]
     )
 
@@ -62,8 +66,8 @@ def generate_cards(context):
     TA_leaveslips = Card(
         header_title="Leave Slips",
         card_links=[
-            CardLink(title="Pending", url="%s?status=P&ta=%s"%(reverse('leaveslips:ta-leaveslip-list'), user.id), number=ls_p),
-            CardLink(title="Marked for fellowship", url="%s?status=F&ta=%s"%(reverse('leaveslips:ta-leaveslip-list'), user.id), number=ls_f),
+            CardLink(title="Pending", url="%s?status=P&ta=%s" % (reverse('leaveslips:ta-leaveslip-list'), user.id), number=ls_p),
+            CardLink(title="Marked for fellowship", url="%s?status=F&ta=%s" % (reverse('leaveslips:ta-leaveslip-list'), user.id), number=ls_f),
         ]
     )
 
@@ -97,7 +101,6 @@ def generate_cards(context):
             CardLink(title="Desginated Services Viewer", url=reverse('services:designated_services_viewer')),
         ]
     )
-
 
     cards.append(TA_admin)
 
@@ -149,8 +152,8 @@ def generate_cards(context):
     cards.append(attendance_card)
 
     schedules_card = Card(
-        header_title = 'Admin',
-        card_links = [
+        header_title='Admin',
+        card_links=[
             CardLink(title="Events", url='admin/schedules/event/'),
             CardLink(title="Schedules", url='admin/schedules/schedule/'),
             CardLink(title="Roll", url='admin/attendance/roll/'),

--- a/ap/leaveslips/views.py
+++ b/ap/leaveslips/views.py
@@ -14,7 +14,7 @@ from braces.views import GroupRequiredMixin
 from .models import IndividualSlip, GroupSlip, LeaveSlip
 from .forms import IndividualSlipForm, GroupSlipForm
 from .serializers import IndividualSlipSerializer, IndividualSlipFilter, GroupSlipSerializer, GroupSlipFilter
-from accounts.models import TrainingAssistant
+from accounts.models import TrainingAssistant, Statistics
 from attendance.views import react_attendance_context
 from aputils.utils import modify_model_status
 from aputils.trainee_utils import trainee_from_user
@@ -87,12 +87,22 @@ class TALeaveSlipList(GroupRequiredMixin, generic.TemplateView):
     individual = IndividualSlip.objects.all().order_by('status', 'submitted')
     group = GroupSlip.objects.all().order_by('status', 'submitted')  # if trainee is in a group leave slip submitted by another user
 
+    s, create = Statistics.objects.get_or_create(trainee=self.request.user)
+
+    slip_setting = s.settings.get('leaveslip')
+    selected_ta = slip_setting.get('selected_ta', self.request.user.id)
+    status = slip_setting.get('selected_status', 'P')
+
     if self.request.method == 'POST':
       selected_ta = int(self.request.POST.get('leaveslip_ta_list'))
       status = self.request.POST.get('leaveslip_status')
     else:
-      selected_ta = self.request.user.id
-      status = self.request.GET.get('status', 'P')
+      status = self.request.GET.get('status', status)
+      selected_ta = self.request.GET.get('ta', selected_ta)
+
+    s.settings['leaveslip']['selected_ta'] = selected_ta
+    s.settings['leaveslip']['selected_status'] = status
+    s.save()
 
     ta = None
     if selected_ta > 0:
@@ -103,6 +113,10 @@ class TALeaveSlipList(GroupRequiredMixin, generic.TemplateView):
     if status != "-1":
       individual = individual.filter(status=status)
       group = group.filter(status=status)
+
+    # Prefetch for performance
+    individual.select_related('trainee', 'TA', 'TA_informed').prefetch_related('rolls')
+    group.select_related('trainee', 'TA', 'TA_informed').prefetch_related('trainees')
 
     ctx['TA_list'] = TrainingAssistant.objects.all()
     ctx['leaveslips'] = chain(individual, group)  # combines two querysets

--- a/ap/leaveslips/views.py
+++ b/ap/leaveslips/views.py
@@ -92,7 +92,7 @@ class TALeaveSlipList(GroupRequiredMixin, generic.TemplateView):
       status = self.request.POST.get('leaveslip_status')
     else:
       selected_ta = self.request.user.id
-      status = 'P'
+      status = self.request.GET.get('status', 'P')
 
     ta = None
     if selected_ta > 0:

--- a/ap/leaveslips/views.py
+++ b/ap/leaveslips/views.py
@@ -87,7 +87,7 @@ class TALeaveSlipList(GroupRequiredMixin, generic.TemplateView):
     individual = IndividualSlip.objects.all().order_by('status', 'submitted')
     group = GroupSlip.objects.all().order_by('status', 'submitted')  # if trainee is in a group leave slip submitted by another user
 
-    s, create = Statistics.objects.get_or_create(trainee=self.request.user)
+    s, _ = Statistics.objects.get_or_create(trainee=self.request.user)
 
     slip_setting = s.settings.get('leaveslip')
     selected_ta = slip_setting.get('selected_ta', self.request.user.id)

--- a/ap/lifestudies/forms.py
+++ b/ap/lifestudies/forms.py
@@ -52,7 +52,7 @@ class NewSummaryForm(forms.ModelForm):
   def save(self, commit=True):
     summary = super(NewSummaryForm, self).save(commit=False)
     if commit:
-      #update the last book for discipline for trainee
+      # update the last book for discipline for trainee
       t = summary.discipline.trainee
       stat_str = str(summary.book.id) + ':' + str(summary.chapter)
       # Update or create for the first time new statistics


### PR DESCRIPTION
- Saves last selected filter for ta leaveslip view (Using statistics model to save settings)
- Smart card link selects correct filter. (Used to default to pending leaveslips view)

**Warning**
Before you merge on live server, make sure it is running postgresql version 9.4+. To check the actual running version use `pg_lsclusters`.

Follow guide here: https://gorails.com/guides/upgrading-postgresql-version-on-ubuntu-server