### PR TITLE
Revoking just for the short term to AM edits

### DIFF
--- a/ap/aputils/groups.py
+++ b/ap/aputils/groups.py
@@ -32,7 +32,7 @@ GROUP_PERMISSIONS = [
     ('training_assistant', APPS),
     ('saturday_training_assistant', APPS),
     ('absent_trainee_roster', ['absent_trainee_roster']),
-    ('attendance_monitors', ['attendance', 'seating', 'schedules', 'leaveslips', 'teams', 'aputils', 'houses']),
+    ('attendance_monitors', ['attendance', 'seating', 'leaveslips', 'teams', 'aputils', 'houses']),
     ('av', ['audio']),
     ('dev', APPS),
     ('networks', []),

--- a/ap/aputils/templatetags/smart_cards.py
+++ b/ap/aputils/templatetags/smart_cards.py
@@ -154,8 +154,9 @@ def generate_cards(context):
     schedules_card = Card(
         header_title='Admin',
         card_links=[
-            CardLink(title="Events", url='admin/schedules/event/'),
-            CardLink(title="Schedules", url='admin/schedules/schedule/'),
+# Revoking the permissions just for the short term to stop AM's from changing schedules "benfin"
+#           CardLink(title="Events", url='admin/schedules/event/'),
+#           CardLink(title="Schedules", url='admin/schedules/schedule/'),
             CardLink(title="Roll", url='admin/attendance/roll/'),
         ]
     )


### PR DESCRIPTION
We need to stop Attendance monitors from accessing the admin page. Until we find a long term solution. We are going to force them to talk to us for schedule changes in the time being