### PR TITLE
Italicization of trainee's that marked read on announcements

### DIFF
--- a/ap/announcements/templates/announcements/_announcement_trainees.html
+++ b/ap/announcements/templates/announcements/_announcement_trainees.html
@@ -5,4 +5,9 @@
     {{ trainee }}
     {% if not forloop.last %}, {% endif %}
   {% endfor %}
+
+  {% for trainee in announcement.trainees_read.all %}
+    <i> {{ trainee }} </i>
+    {% if not forloop.last %}, {% endif %}
+  {% endfor %}
 {% endif %}


### PR DESCRIPTION
To deal with a requested issue where after trainee's read an announcement they would just disappear off of the announcement. Now instead their name gets italicized after the trainee has read the popup announcement.