### PR TITLE
Exam updates

### DIFF
--- a/ap/exams/templates/exams/exam.html
+++ b/ap/exams/templates/exams/exam.html
@@ -36,7 +36,10 @@
           {% csrf_token %}
           <ol id="question-list">
             {% for section, response, score, comments in data %}
-              Instructions: {{ section.instructions }}. You must answer at least {{ section.required_number_to_submit }} questions for this section in order to submit the exam.
+              <h4> {{ section.section_type }} </h4>
+              Instructions: {{ section.instructions }}
+              </br>
+              You must answer at least {{ section.required_number_to_submit }} questions for this section in order to submit the exam.
               <input type="hidden" value="{{ section.id }}" name="section_id">
               <input type="hidden" value="{{ section.type }}" name="section_type">
               {% for question in section.questions %}

--- a/ap/exams/templates/exams/exam_preview.html
+++ b/ap/exams/templates/exams/exam_preview.html
@@ -31,7 +31,10 @@
           {% csrf_token %}
           <ol id="question-list">
             {% for section, response, score, comments in data %}
-              <h4> {{ section.instructions }} </h4>
+              <h4> {{ section.section_type }} </h4>
+              Instructions: {{ section.instructions }}
+              </br>
+              You must answer at least {{ section.required_number_to_submit }} questions for this section in order to submit the exam.
               <input type="hidden" value="{{ section.id }}" name="section_id">
               <input type="hidden" value="{{ section.type }}" name="section_type">
               {% for question in section.questions %}

--- a/ap/exams/utils.py
+++ b/ap/exams/utils.py
@@ -9,7 +9,7 @@ from .models import Exam, Makeup, Responses, Section
 
 @register.filter
 def get_essay_unique_id(section_id, forloop_counter):
-    return int(section_id) + int(forloop_counter)
+    return int(section_id) * int(forloop_counter)
 
 
 # Returns the section referred to by the args, None if it does not exist


### PR DESCRIPTION
A few changes to front-end design, and fix to word count. Ensures id is unique by multiplying counter by section-id. Looks like this does work for trainees, but doesn't work for exam preview on ta side (looks like it never worked on the ta preview page). This fix should cover the edge case where we have multiple essay questions for multiple essay sections.