### PR TITLE
fix permissions for saturday tas

### DIFF
--- a/ap/accounts/management/commands/populate_saturday_tas.py
+++ b/ap/accounts/management/commands/populate_saturday_tas.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         ta_obj = User.objects.get(firstname=firstname, lastname=lastname)
         print 'added ', ta_obj
         sta_perm.user_set.add(ta_obj)
-        ta_perm.user_set.remove(ta_obj)
+        ta_perm.user_set.add(ta_obj)
       except ObjectDoesNotExist:
         print ta, 'does not exist'
 

--- a/ap/accounts/management/commands/populate_tas.py
+++ b/ap/accounts/management/commands/populate_tas.py
@@ -20,23 +20,25 @@ class Command(BaseCommand):
     tas = ['Andrew Li', 'Jerome Keh', 'Joseph Bang', 'Paul Deng', 'Walt Hale', 'Joe Prim', 'Oscar Tuktarov', 'Doug Gedeon', 'Dennis Higashi']
     sister_tas = ['Nikki Miao', 'Hannah Chumreonlert', 'Raizel Macaranas', 'Ann Buntain', 'Annie Uy']
     perm = Group.objects.get(name='training_assistant')
+    rperm = Group.objects.get(name='regular_training_assistant')
 
     for ta in tas:
       u = self._create_ta(ta)
       u.gender = 'B'
+      rperm.user_set.add(u)
       perm.user_set.add(u)
       u.save()
 
     for ta in sister_tas:
       u = self._create_ta(ta)
       u.gender = 'S'
+      rperm.user_set.add(u)
       perm.user_set.add(u)
       u.save()
 
     user = User(is_active=True, email='ap@gmail.com', firstname='AP', lastname='DEV', is_staff=True, is_admin=True, is_superuser=True)
     user.set_password('ap')
     user.save()
-
 
   def handle(self, *args, **options):
     User.objects.all().delete()

--- a/ap/aputils/groups.py
+++ b/ap/aputils/groups.py
@@ -29,8 +29,9 @@ def add_permissions(group, app_label_list):
 
 APPS = list(settings.APPS)
 GROUP_PERMISSIONS = [
+    ('regular_training_assistant', []),
     ('training_assistant', APPS),
-    ('saturday_training_assistant', APPS),
+    ('saturday_training_assistant', []),
     ('absent_trainee_roster', ['absent_trainee_roster']),
     ('attendance_monitors', ['attendance', 'seating', 'leaveslips', 'teams', 'aputils', 'houses']),
     ('av', ['audio']),

--- a/ap/attendance/views.py
+++ b/ap/attendance/views.py
@@ -52,7 +52,7 @@ def react_attendance_context(trainee):
   rolls = rolls.filter(id__in=main_rolls)
   individualslips = IndividualSlip.objects.filter(trainee=trainee).prefetch_related('rolls')
   groupslips = GroupSlip.objects.filter(Q(trainees__in=[trainee])).distinct().prefetch_related('trainees')
-  TAs = TrainingAssistant.objects.filter(groups__name='training_assistant')
+  TAs = TrainingAssistant.objects.filter(groups__name='regular_training_assistant')
   term = [Term.current_term()]
   ctx = {
       'events_bb': listJSONRenderer.render(AttendanceEventWithDateSerializer(events, many=True).data),

--- a/ap/leaveslips/views.py
+++ b/ap/leaveslips/views.py
@@ -135,7 +135,7 @@ class TALeaveSlipList(GroupRequiredMixin, generic.TemplateView):
     individual.select_related('trainee', 'TA', 'TA_informed').prefetch_related('rolls')
     group.select_related('trainee', 'TA', 'TA_informed').prefetch_related('trainees')
 
-    ctx['TA_list'] = TrainingAssistant.objects.filter(groups__name='training_assistant')
+    ctx['TA_list'] = TrainingAssistant.objects.filter(groups__name='regular_training_assistant')
     ctx['leaveslips'] = chain(individual, group)  # combines two querysets
     ctx['selected_ta'] = ta
     ctx['status_list'] = LeaveSlip.LS_STATUS[:-1]  # Removes Sister Approved Choice


### PR DESCRIPTION
Address 

> **MP** Saturday helper brothers cannot approve web access requests getting a forbidden error. May affect other modules

item on #1053. Put all Saturday and regular TAs in `training_assistant` group. Put Saturday TAs in `saturday_training_assistant` group. Put regular TAs in `regular_training_assistant` group. Use groups appropriately.

Reason for doing it this way: Saturday TAs and regular TAs should have the same permissions. Right now everything in our code uses the `training_assistant` group. When we added Saturday TAs to `saturday_training_assistant` and removed them from `training_assistant` they lost privileges. This way we just have to be specific which TAs we want.

We'll have to add everyone to the right groups after merging

(populate.py files updated only for showing how these groups are used, we wouldn't actually need to use them)