### PR TITLE
Trainee view group slip improvements

### DIFF
--- a/ap/attendance/templates/attendance/attendance_react.html
+++ b/ap/attendance/templates/attendance/attendance_react.html
@@ -7,6 +7,7 @@
 
 {% block references %}
   {% render_bundle 'attendance' 'css' %}
+  {{ trainee_select_form.media }}
 {% endblock %}
 
 {% block scripts %}
@@ -19,6 +20,7 @@
 {% endblock %}
 
 {% block content %}
+{% include "popups/trainee_select_modal.html" %}
 <div id="react-attendance-root"></div>
   {% render_bundle 'attendance' 'js' %}
 {% endblock %}

--- a/ap/attendance/views.py
+++ b/ap/attendance/views.py
@@ -32,6 +32,7 @@ from terms.serializers import TermSerializer
 
 from braces.views import GroupRequiredMixin
 
+from ap.forms import TraineeSelectForm
 from aputils.trainee_utils import trainee_from_user, is_trainee
 from aputils.eventutils import EventUtils
 from aputils.decorators import group_required
@@ -64,6 +65,7 @@ def react_attendance_context(trainee):
       'groupslips_bb': listJSONRenderer.render(GroupSlipSerializer(groupslips, many=True).data),
       'TAs_bb': listJSONRenderer.render(TrainingAssistantSerializer(TAs, many=True).data),
       'term_bb': listJSONRenderer.render(TermSerializer(term, many=True).data),
+      'trainee_select_form': TraineeSelectForm()
   }
   return ctx
 

--- a/ap/static/js/trainee_select.js
+++ b/ap/static/js/trainee_select.js
@@ -1,4 +1,15 @@
-$(document).ready(function(){
+// data: array of trainee ids to be added into the Trainee field
+// function selects trainees in Trainee Select2 field.
+let addTrainees = (trainee_ids) => {
+  var curr = ($('#id_trainees').val());
+  if (curr) {
+    trainee_ids = [...new Set([...curr, ...trainee_ids])];
+  }
+  $('#id_trainees').val(trainee_ids).trigger('change');
+  return;
+}
+
+$(document).ready(function() {
   $('body').append(TRAINEE_SELECT_MODAL_HTML);
   $('#id_team').djangoSelect2({width: '100%'});
   $('#id_house').djangoSelect2({width: '100%'});
@@ -7,15 +18,17 @@ $(document).ready(function(){
   var base_url = window.location.protocol + '//' + window.location.host;
   var api_base = '/api'
 
+
   function getTrainees(data) {
-    var trainee_groups = {'terms': [],
-                'gender': [],
-                'hc': [],
-                'team_types': [],
-                'teams': [],
-                'houses': [],
-                'localities': []
-               }
+    var trainee_groups = {
+      'terms': [],
+      'gender': [],
+      'hc': [],
+      'team_types': [],
+      'teams': [],
+      'houses': [],
+      'localities': []
+    };
 
     var deferreds = []; // all ajax deferred objects get pushed into here
 
@@ -145,17 +158,6 @@ $(document).ready(function(){
     return trainee_ids;
   }
 
-  // data: array of trainee ids to be added into the Trainee field
-  // function selects trainees in Trainee Select2 field.
-  function addTrainees(trainee_ids) {
-    var curr = ($('#id_trainees').val())
-    if (curr) {
-      trainee_ids = [...new Set([...curr, ...trainee_ids])]
-    }
-    $('#id_trainees').val(trainee_ids).trigger('change');
-    return;
-  }
-
   $('#add_trainees').click(function(event) {
     event.preventDefault();
     form_data = {
@@ -170,7 +172,7 @@ $(document).ready(function(){
     getTrainees(form_data);
     clearForm();
     $('#trainee_select').modal('hide');
-  })
+  });
 
   function getValues(object) {
     var values = [];
@@ -187,4 +189,4 @@ $(document).ready(function(){
     $('#id_house').select2().val(null).trigger('change');
     $('#id_locality').select2() .val(null).trigger('change');
   }
-})
+});

--- a/libraries/react/scripts/actions.js
+++ b/libraries/react/scripts/actions.js
@@ -84,8 +84,6 @@ export const postRollSlip = (rollSlip, selectedEvents, slipId) => {
     return function(dispatch) {
       dispatch(postRoll(rollSlip, selectedEvents, slipId, true));
     }
-  } else {
-    // dispatch(receiveResponse('Error no data for roll or slips'));
   }
 }
 
@@ -131,18 +129,11 @@ export const postRoll = (values) => {
     "date": null
   }
   let selectedEvents = values.selectedEvents;
-  if (selectedEvents.length == 0) {
-    //need to create an error action
-    return function(dispatch) {
-      // dispatch(receiveResponse('error no events selected'));
-    }
-  } else {
-    for (var i = 0; i < selectedEvents.length; i++) {
-      rolls.push(Object.assign({}, roll, {
-        event: selectedEvents[i].id,
-        date: format(selectedEvents[i].start_datetime, 'YYYY-MM-DD')
-      }));
-    }
+  for (var i = 0; i < selectedEvents.length; i++) {
+    rolls.push(Object.assign({}, roll, {
+      event: selectedEvents[i].id,
+      date: format(selectedEvents[i].start_datetime, 'YYYY-MM-DD')
+    }));
   }
   return function(dispatch) {
     var data = null;
@@ -241,8 +232,21 @@ export const changeTraineeView = (trainee) => {
   }
 }
 
+export const duplicateSlip = (values) => {
+  let type = CHANGE_LEAVESLIP_FORM
+  if (values.classname == 'group') {
+    type = CHANGE_GROUPSLIP_FORM
+  }
+  return {
+    type: type,
+    values: {
+      ...values,
+      id: undefined,
+    }
+  }
+}
+
 export const CHANGE_LEAVESLIP_FORM = 'CHANGE_LEAVESLIP_FORM'
-  //values here is all the values of the form
 export const changeLeaveSlipForm = (values) => {
   return {
     type: CHANGE_LEAVESLIP_FORM,
@@ -374,12 +378,13 @@ export const editGroupLeaveSlip = (slip) => {
 
 export const deleteLeaveSlip = (slip) => {
   return function(dispatch) {
+    dispatch(showCalendar(0));
     dispatch(destroyLeaveSlip(slip));
     return $.ajax({
       url: '/api/individualslips/' + slip.id.toString(),
       type: 'DELETE',
       success: function(data, status, jqXHR) {
-        // dispatch(receiveResponse(status));
+        new Notification(Notification.SUCCESS, "Leave slip deleted!").show();
       },
       error: function(jqXHR, textStatus, errorThrown) {
         console.log('Slip delete error!');
@@ -441,7 +446,6 @@ export const postGroupSlip = (gSlip) => {
         if (slip.trainees.indexOf(getState().form.traineeView.id) >= 0) {
           dispatch(submitGroupSlip(data));
         }
-        // dispatch(receiveResponse(status));
         dispatch(resetGroupslipForm());
         new Notification(Notification.SUCCESS, 'Saved').show();
       },
@@ -463,12 +467,13 @@ export const destroyGroupSlip = (slip) => {
 
 export const deleteGroupSlip = (slip) => {
   return function(dispatch) {
+    dispatch(showCalendar(0));
     dispatch(destroyGroupSlip(slip));
     return $.ajax({
       url: '/api/groupslips/' + slip.id.toString(),
       type: 'DELETE',
       success: function(data, status, jqXHR) {
-        // dispatch(receiveResponse(status));
+        new Notification(Notification.SUCCESS, "Group slip deleted!").show();
       },
       error: function(jqXHR, textStatus, errorThrown) {
         console.log('Slip delete error!');

--- a/libraries/react/scripts/components/GroupSlipForm.js
+++ b/libraries/react/scripts/components/GroupSlipForm.js
@@ -6,6 +6,7 @@ import types from 'react-formal-inputs'
 import yup from 'yup'
 
 import { GROUP_SLIP_TYPES, INFORMED } from '../constants'
+import { changeGroupSlipForm } from '../actions'
 import { GroupSlipSchema } from './schemas'
 import LeaveSlipNote from './LeaveSlipNote'
 import SelectedEventsField from './SelectedEventsField'
@@ -17,6 +18,18 @@ import TAComments from './TAComments'
 import SubmitButton from './SubmitButton'
 
 Form.addInputTypes(types)
+
+addTrainees = (trainee_ids) => {
+  let prev_trainees = store.getState().form.groupSlip.trainees.filter((t) => trainee_ids.indexOf(t.id) < 0).map((t) => t.id);
+  trainee_ids += prev_trainees;
+  let trainees = store.getState().trainees.filter((t) => trainee_ids.indexOf(t.id) >= 0);
+  store.dispatch(changeGroupSlipForm(
+    {
+      ...store.getState().form.groupSlip,
+      trainees: trainees,
+    }
+  ));
+}
 
 const GroupSlipForm = ({...props}) => {
   let schema = GroupSlipSchema(props);
@@ -33,7 +46,7 @@ const GroupSlipForm = ({...props}) => {
       >
         <b>Select Trainees</b>
         <Form.Field type='multiSelect' data={props.trainees} name='trainees' valueField='id' textField='name' className='dt-leaveslip__trainees' />
-
+        <button type="button" className="btn btn-primary dt-leaveslip__trainee-group" data-toggle="modal" data-target="#trainee_select">Add Trainee Group</button>
         <SelectedEventsField />
 
         <SlipTypesField slipTypes={GROUP_SLIP_TYPES} lastSlips={[]} />

--- a/libraries/react/scripts/components/SlipDetail.js
+++ b/libraries/react/scripts/components/SlipDetail.js
@@ -2,14 +2,17 @@ import React, { Component } from 'react'
 import { format } from 'date-fns'
 import { Button } from 'react-bootstrap'
 
+import { ATTENDANCE_MONITOR_GROUP } from '../constants'
 import SlipStatusIcon from './SlipStatusIcon'
 
 let dateFormat = 'M/D/YY'
 let datetimeFormat = 'M/D/YY h:mm a'
 
-const SlipDetail = ({slip, deleteSlip, onClick }) => {
+const SlipDetail = ({trainee, slip, deleteSlip, onClick }) => {
   let click = () => onClick(slip)
   let isUnfinalized = '--unfinalized'
+  let isAM = trainee.groups.indexOf(ATTENDANCE_MONITOR_GROUP) >= 0
+  let isSubmitter = trainee.id == slip.trainee
   return (
   <div className={"row summary__leaveslips-row" + isUnfinalized} onClick={() => click(slip)}>
     <div className="col-xs-2">{format(new Date(slip.submitted), dateFormat)}</div>
@@ -24,7 +27,7 @@ const SlipDetail = ({slip, deleteSlip, onClick }) => {
     </div>
     <div className="col-xs-1">{slip.type.charAt(0).toUpperCase() + slip.type.slice(1).toLowerCase()}</div>
     <div className="col-xs-1 col-xs-offset-1">
-      {!slip.finalized &&
+      {(isAM || (!slip.finalized && isSubmitter)) &&
         <Button className="summary__leaveslips-button pull-right" bsSize="xsmall" bsStyle="danger"
           onClick={e => {
             if (confirm('Are you sure you want to delete this leave slip?')) {

--- a/libraries/react/scripts/components/SlipDetail.js
+++ b/libraries/react/scripts/components/SlipDetail.js
@@ -2,17 +2,14 @@ import React, { Component } from 'react'
 import { format } from 'date-fns'
 import { Button } from 'react-bootstrap'
 
-import { ATTENDANCE_MONITOR_GROUP } from '../constants'
 import SlipStatusIcon from './SlipStatusIcon'
 
 let dateFormat = 'M/D/YY'
 let datetimeFormat = 'M/D/YY h:mm a'
 
-const SlipDetail = ({trainee, slip, deleteSlip, onClick }) => {
+const SlipDetail = ({ slip, deleteSlip, onClick }) => {
   let click = () => onClick(slip)
   let isUnfinalized = '--unfinalized'
-  let isAM = trainee.groups.indexOf(ATTENDANCE_MONITOR_GROUP) >= 0
-  let isSubmitter = trainee.id == slip.trainee
   return (
   <div className={"row summary__leaveslips-row" + isUnfinalized} onClick={() => click(slip)}>
     <div className="col-xs-2">{format(new Date(slip.submitted), dateFormat)}</div>
@@ -27,18 +24,6 @@ const SlipDetail = ({trainee, slip, deleteSlip, onClick }) => {
     </div>
     <div className="col-xs-1">{slip.type.charAt(0).toUpperCase() + slip.type.slice(1).toLowerCase()}</div>
     <div className="col-xs-1 col-xs-offset-1">
-      {(isAM || (!slip.finalized && isSubmitter)) &&
-        <Button className="summary__leaveslips-button pull-right" bsSize="xsmall" bsStyle="danger"
-          onClick={e => {
-            if (confirm('Are you sure you want to delete this leave slip?')) {
-              deleteSlip(slip)
-            }
-            e.stopPropagation()
-          }}
-        >
-          <i className="fa fa-close"></i>
-        </Button>
-      }
     </div>
   </div>
   )

--- a/libraries/react/scripts/components/SlipTitle.js
+++ b/libraries/react/scripts/components/SlipTitle.js
@@ -1,7 +1,10 @@
 import React, { Component } from 'react'
 import { Button } from 'react-bootstrap'
+import { ATTENDANCE_MONITOR_GROUP } from '../constants'
 
 const SlipTitle = (props) => {
+  let isAM = props.trainee.groups.indexOf(ATTENDANCE_MONITOR_GROUP) >= 0
+  let isSubmitter = props.trainee.id == props.form.trainee
   let actionText
   if (!props.form.id) {
     actionText = 'Submit'
@@ -13,7 +16,20 @@ const SlipTitle = (props) => {
   return (
     <h4 className='dt-leaveslip__title'>
       {actionText + ' Leave Slip'}&nbsp;
-      {props.form.id && <Button onClick={props.resetForm} className="pull-right" bsSize="small">New Leave Slip</Button>}
+      {props.form.id && <a onClick={props.resetForm} className="dt-leaveslip__title__close pull-right"><i className="fa fa-close"></i></a>}
+      {props.form.id && <Button onClick={() => props.duplicateSlip(props.form)} className="pull-right dt-leaveslip__title__button" bsSize="small">Duplicate Slip</Button>}
+      {props.form.id && (isAM || (!props.form.finalized && isSubmitter)) &&
+        <Button className="dt-leaveslip__title__button pull-right" bsSize="xsmall" bsStyle="danger"
+          onClick={(e) => {
+            if (confirm('Are you sure you want to delete this leave slip?')) {
+              props.deleteSlip(props.form)
+            }
+            e.stopPropagation()
+          }}
+        >
+          Delete Slip
+        </Button>
+      }
     </h4>
   )
 }

--- a/libraries/react/scripts/components/Summary.js
+++ b/libraries/react/scripts/components/Summary.js
@@ -43,7 +43,7 @@ const Summary = (p) => {
           <div className="col-xs-2">Reason</div>
         </div>
         {p.leaveslips.sort((s1, s2) => s1.submitted > s2.submitted ? -1 : 1)
-          .map((slip, i) => <SlipDetail trainee={p.trainee} slip={slip} key={i} onClick={() => p.editSlip(slip)} deleteSlip={p.deleteSlip} /> )}
+          .map((slip, i) => <SlipDetail slip={slip} key={i} onClick={() => p.editSlip(slip)} deleteSlip={p.deleteSlip} /> )}
         </div> : ''
       }
 

--- a/libraries/react/scripts/components/Summary.js
+++ b/libraries/react/scripts/components/Summary.js
@@ -43,7 +43,7 @@ const Summary = (p) => {
           <div className="col-xs-2">Reason</div>
         </div>
         {p.leaveslips.sort((s1, s2) => s1.submitted > s2.submitted ? -1 : 1)
-          .map((slip, i) => <SlipDetail slip={slip} key={i} onClick={() => p.editSlip(slip)} deleteSlip={p.deleteSlip} /> )}
+          .map((slip, i) => <SlipDetail trainee={p.trainee} slip={slip} key={i} onClick={() => p.editSlip(slip)} deleteSlip={p.deleteSlip} /> )}
         </div> : ''
       }
 
@@ -57,7 +57,7 @@ const Summary = (p) => {
           <div className="col-xs-2">Reason</div>
         </div>
         {p.groupslips.sort((s1, s2) => s1.submitted > s2.submitted ? -1 :1)
-          .map((slip, i) => <SlipDetail slip={slip} key={i} onClick={() => p.editGroupSlip(slip)} deleteSlip={p.deleteGroupSlip} /> )}
+          .map((slip, i) => <SlipDetail trainee={p.trainee} slip={slip} key={i} onClick={() => p.editGroupSlip(slip)} deleteSlip={p.deleteGroupSlip} /> )}
         </div> : ''
       }
 

--- a/libraries/react/scripts/containers/GroupSlipPane.js
+++ b/libraries/react/scripts/containers/GroupSlipPane.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { postGroupSlip, changeGroupSlipForm, resetGroupslipForm } from '../actions'
+import { postGroupSlip, changeGroupSlipForm, resetGroupslipForm, duplicateSlip, deleteGroupSlip } from '../actions'
 import { lastLeaveslips } from '../selectors/selectors'
 import GroupSlipForm from '../components/GroupSlipForm'
 
@@ -14,6 +14,7 @@ const mapStateToProps = (state) => {
     },
     tas: state.tas,
     trainees: state.trainees,
+    trainee: state.trainee,
   }
 }
 const mapDispatchToProps = (dispatch) => {
@@ -21,6 +22,8 @@ const mapDispatchToProps = (dispatch) => {
     postGroupSlip: (values) => { dispatch(postGroupSlip(values)) },
     changeGroupSlipForm: (values) => { dispatch(changeGroupSlipForm(values)) },
     resetForm: () => { dispatch(resetGroupslipForm()) },
+    duplicateSlip: (values) => { dispatch(duplicateSlip(values)) },
+    deleteSlip: (slip) => { dispatch(deleteGroupSlip(slip)) },
   }
 }
 

--- a/libraries/react/scripts/containers/LeaveSlipPane.js
+++ b/libraries/react/scripts/containers/LeaveSlipPane.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { postLeaveSlip, changeLeaveSlipForm, resetLeaveslipForm } from '../actions'
+import { postLeaveSlip, changeLeaveSlipForm, resetLeaveslipForm, duplicateSlip, deleteLeaveSlip } from '../actions'
 import { lastLeaveslips } from '../selectors/selectors'
 import LeaveSlipForm from '../components/LeaveSlipForm'
 
@@ -13,6 +13,7 @@ const mapStateToProps = (state) => {
       traineeView: state.form.traineeView
     },
     tas: state.tas,
+    trainee: state.trainee,
   }
 }
 const mapDispatchToProps = (dispatch) => {
@@ -20,6 +21,8 @@ const mapDispatchToProps = (dispatch) => {
     postLeaveSlip: (values) => { dispatch(postLeaveSlip(values)) },
     changeLeaveSlipForm: (values) => { dispatch(changeLeaveSlipForm(values)) },
     resetForm: () => { dispatch(resetLeaveslipForm()) },
+    duplicateSlip: (values) => { dispatch(duplicateSlip(values)) },
+    deleteSlip: (slip) => { dispatch(deleteLeaveSlip(slip)) },
   }
 }
 

--- a/libraries/react/scripts/containers/SummaryPane.js
+++ b/libraries/react/scripts/containers/SummaryPane.js
@@ -8,6 +8,7 @@ const mapStateToProps = (state) => {
     eventsRolls: getEventsByRollStatus(state),
     groupslips: getGroupSlipsforPeriod(state),
     leaveslips: getLeaveSlipsforPeriod(state),
+    trainee: state.trainee,
   }
 }
 

--- a/libraries/react/scripts/containers/SummaryPane.js
+++ b/libraries/react/scripts/containers/SummaryPane.js
@@ -8,7 +8,6 @@ const mapStateToProps = (state) => {
     eventsRolls: getEventsByRollStatus(state),
     groupslips: getGroupSlipsforPeriod(state),
     leaveslips: getLeaveSlipsforPeriod(state),
-    trainee: state.trainee,
   }
 }
 

--- a/libraries/react/scss/ap_react.scss
+++ b/libraries/react/scss/ap_react.scss
@@ -136,6 +136,9 @@ textarea {
     border: solid thin #ccc;
     margin:0;
     margin-top:-1px;
+    &__trainee-group {
+      margin-bottom: 10px;
+    }
     &__trainee-select {
       margin-bottom: 10px;
     }

--- a/libraries/react/scss/ap_react.scss
+++ b/libraries/react/scss/ap_react.scss
@@ -145,6 +145,13 @@ textarea {
     &__title {
       font-size: 17px;
       margin-bottom: 20px;
+      &__close {
+        cursor: pointer;
+      }
+      &__button {
+        margin-top: -7px;
+        margin-right: 10px;
+      }
     }
     &__entries {
       padding: 10px 15px 10px;


### PR DESCRIPTION
* Adds trainee group select button for group slips, would be really good for trainees to have for submitting group slips e.g. team monitors, service overseers. Currently it's only available to AMs on the admin.
* Only allow submitter (and AMs) to delete group leave slips
* Move delete button and add duplicate button to slip detail view from summary