### PR TITLE
should be -submitted

### DIFF
--- a/ap/leaveslips/views.py
+++ b/ap/leaveslips/views.py
@@ -45,7 +45,7 @@ class IndividualSlipUpdate(LeaveSlipUpdate):
   def get_context_data(self, **kwargs):
     ctx = super(IndividualSlipUpdate, self).get_context_data(**kwargs)
     if self.get_object().type in ['MEAL', 'NIGHT']:
-      IS_list = IndividualSlip.objects.filter(status='A', trainee=self.get_object().get_trainee_requester(), type=self.get_object().type).order_by('submitted')
+      IS_list = IndividualSlip.objects.filter(status='A', trainee=self.get_object().get_trainee_requester(), type=self.get_object().type).order_by('-submitted')
       most_recent_IS = IS_list.first()
       if most_recent_IS and most_recent_IS != self.get_object():
         last_date = most_recent_IS.rolls.all().order_by('date').last().date


### PR DESCRIPTION
My bad for merging that pull request. Kind of fixes #1067

I don't want to consider the case right now where a trainee submits two months in advance night out leave slip and then his one month in advance leave slip, while having a night out leave slip from a week ago. I guess the correct thing to do would be to get the night out slip with the closest event date attached, submission time should have nothing to do with it.