### PR TITLE
Allow uploads to be downloaded

### DIFF
--- a/ap/ap/settings/base.py
+++ b/ap/ap/settings/base.py
@@ -406,3 +406,6 @@ AUDIO_FILES_URL = MEDIA_URL + 'audio/Attendance Server'
 
 SELECT2_JS = ''
 SELECT2_CSS = ''
+
+# by default allow rw- r-- r--
+FILE_UPLOAD_PERMISSIONS = 0o644


### PR DESCRIPTION
Fixes #980 

We had no Django setting set before so the permissions of uploaded files depended on the OS. Don't know why it changed but now it's correctly set to allow read access. We're going to have to add more granular limits in Django if we want. 

https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-FILE_UPLOAD_PERMISSIONS