### PR TITLE
#Days Absent Fix

### DIFF
--- a/ap/absent_trainee_roster/utils.py
+++ b/ap/absent_trainee_roster/utils.py
@@ -88,7 +88,7 @@ def calculate_trainee_absent_freq(date):
         continue
       r = get_or_create_roster(d)
       trainees = map(lambda e: e['absentee'], r.entry_set.all().values('absentee'))
-      # removed couples houses from unreported list
+      # removed couples and commuters houses from unreported list
       is_unreported = absentee.house in r.unreported_houses.all().exclude(name__icontains="Couple").exclude(name__icontains="Hall Apt").exclude(name__icontains="COMMUTER")
       if is_unreported:
         unreported.add(absentee.id)

--- a/ap/absent_trainee_roster/utils.py
+++ b/ap/absent_trainee_roster/utils.py
@@ -88,7 +88,8 @@ def calculate_trainee_absent_freq(date):
         continue
       r = get_or_create_roster(d)
       trainees = map(lambda e: e['absentee'], r.entry_set.all().values('absentee'))
-      is_unreported = absentee.house in r.unreported_houses.all()
+      # removed couples houses from unreported list
+      is_unreported = absentee.house in r.unreported_houses.all().exclude(name__icontains="Couple").exclude(name__icontains="Hall Apt").exclude(name__icontains="COMMUTER")
       if is_unreported:
         unreported.add(absentee.id)
       if absentee.id in trainees or is_unreported:


### PR DESCRIPTION
I removed the couples' and commuters' houses from the unreported_houses list. This way, the #Days Absent for couples and commuters will only increment if they are added to the absent trainee list by the absent trainee roster brothers. 

I'm not sure if there is a more elegant way to chain multiple excludes.