### PR TITLE
fix finalization show correct rolls in response

### DIFF
--- a/ap/attendance/views.py
+++ b/ap/attendance/views.py
@@ -639,7 +639,10 @@ def finalize(request):
     roll = Roll(date=period_start, trainee=trainee, status='P', event=event, finalized=True, submitted_by=submitter)
     roll.save()
   listJSONRenderer = JSONRenderer()
-  rolls = listJSONRenderer.render(RollSerializer(Roll.objects.filter(trainee=trainee), many=True).data)
+  if trainee.self_attendance:
+    rolls = listJSONRenderer.render(RollSerializer(Roll.objects.filter(submitted_by=trainee), many=True).data)
+  else:
+    rolls = listJSONRenderer.render(RollSerializer(Roll.objects.filter(trainee=trainee), many=True).data)
 
   return JsonResponse({'rolls': json.loads(rolls)})
 


### PR DESCRIPTION
@billyeh Can you review this? Should fix the issue where trainees, after finalizing attendance, see the attendance record inputted by the attendance monitors rather than their own attendance.
@ruthnan @priscilagonzalez Can you all test this fix?

from #1279 