### PR TITLE
Ta groupslip detail view fixes

### DIFF
--- a/ap/leaveslips/views.py
+++ b/ap/leaveslips/views.py
@@ -35,7 +35,6 @@ class LeaveSlipUpdate(GroupRequiredMixin, generic.UpdateView):
     kwargs['period'] = self.get_object().periods[0]
     ctx.update(react_attendance_context(trainee, request_params=kwargs))
     ctx['Today'] = self.get_object().get_date().strftime('%m/%d/%Y')
-    ctx['SelectedEvents'] = listJSONRenderer.render(AttendanceEventWithDateSerializer(self.get_object().events, many=True).data)
     ctx['default_transfer_ta'] = self.request.user.TA or self.get_object().TA
     return ctx
 

--- a/libraries/react/scripts/components/EventColumn.js
+++ b/libraries/react/scripts/components/EventColumn.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import EventView from './EventView'
 import {format, isSameDay} from 'date-fns'
 
-const EventColumn = ({daysEsr, date, selectedEvents, onEventClick, onHeaderClick}) => {
+const EventColumn = ({daysEsr, date, selectedEvents, show, onEventClick, onHeaderClick}) => {
   var header = format(date, 'ddd D');
   var todayStyle = {};
   if (isSameDay(date, new Date())) {
@@ -44,7 +44,7 @@ EventColumn.PropTypes = {
     slip: PropTypes.object.isRequired,
   }).isRequired).isRequired,
   selectedEvents: PropTypes.arrayOf(PropTypes.object.isRequired).isRequired,
-  onEventClick: PropTypes.func.isRequired
+  onEventClick: PropTypes.func.isRequired,
 }
 
 export default EventColumn

--- a/libraries/react/scripts/components/EventGrid.js
+++ b/libraries/react/scripts/components/EventGrid.js
@@ -4,7 +4,9 @@ import EventColumn from './EventColumn'
 import TimesColumn from '../components/TimesColumn'
 import { joinValidClasses } from '../constants'
 
-const EventGrid = ({eventsByCol, selectedEvents, onEventClick, onHeaderClick, show}) => {
+const EventGrid = ({eventsByCol, selectedEvents, show, onEventClick, onGroupEventClick, onHeaderClick}) => {
+  var eventClickFunction = show == 'groupslip' ? onGroupEventClick : onEventClick
+  var headerClickFunction = show == 'groupslip' ? (evs) => {return} : onHeaderClick
   return (
     <div className="col-md-12">
       <div className="row">
@@ -14,9 +16,10 @@ const EventGrid = ({eventsByCol, selectedEvents, onEventClick, onHeaderClick, sh
             return (<EventColumn
               key={i}
               {...daysEsr}
-              onEventClick={(ev) => onEventClick(ev)}
-              onHeaderClick={(evs) => onHeaderClick(evs)}
+              onEventClick={(ev) => eventClickFunction(ev)}
+              onHeaderClick={(evs) => headerClickFunction(evs)}
               selectedEvents={selectedEvents}
+              show={show}
             />)
           }
         )}
@@ -27,7 +30,8 @@ const EventGrid = ({eventsByCol, selectedEvents, onEventClick, onHeaderClick, sh
 
 EventGrid.propTypes = {
   eventsByCol: PropTypes.arrayOf(PropTypes.object.isRequired).isRequired,
-  onEventClick: PropTypes.func.isRequired
+  onEventClick: PropTypes.func.isRequired,
+  onGroupEventClick: PropTypes.func.isRequired,
 }
 
 export default EventGrid

--- a/libraries/react/scripts/constants.js
+++ b/libraries/react/scripts/constants.js
@@ -154,6 +154,11 @@ export function canFinalizeRolls(rolls, dateDetails) {
   return canFinalizeWeek
 }
 
+// this can't be an arrow function because we need this which is passed in through find or findIndex's second argument
+export const findEvent = function(elem) {
+  return elem.id == this.event.id && elem.start_datetime == this.event.start_datetime && elem.end_datetime == this.event.end_datetime
+}
+
 export const compareLeaveslipEvents = (e1, e2) => {
   return new Date(e1.date) < new Date(e2.date) ? -1 : 1
 }

--- a/libraries/react/scripts/containers/GridContainer.js
+++ b/libraries/react/scripts/containers/GridContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { toggleEvent, toggleDaysEvents } from '../actions'
+import { toggleEvent, toggleGroupEvent, toggleDaysEvents } from '../actions'
 import EventGrid from '../components/EventGrid'
 import { getEventsByCol } from '../selectors/selectors'
 
@@ -29,6 +29,9 @@ const mapDispatchToProps = (dispatch) => {
   return {
     onEventClick: (ev) => {
       dispatch(toggleEvent(ev))
+    },
+    onGroupEventClick: (ev) => {
+      dispatch(toggleGroupEvent(ev))
     },
     onHeaderClick: (evs) => {
       for (let ev of evs) {

--- a/libraries/react/scripts/reducers/reducer.js
+++ b/libraries/react/scripts/reducers/reducer.js
@@ -1,12 +1,12 @@
 //set manipulations used to do array computations easily from https://www.npmjs.com/package/set-manipulator
 import { union, intersection, difference, complement, equals } from 'set-manipulator';
 
-import { CHANGE_DATE, SUBMIT_ROLL, UPDATE_ATTENDANCE, UPDATE_EVENTS, UPDATE_TRAINEE_VIEW, TOGGLE_EVENT,
+import { CHANGE_DATE, SUBMIT_ROLL, UPDATE_ATTENDANCE, UPDATE_EVENTS, UPDATE_TRAINEE_VIEW, TOGGLE_EVENT, TOGGLE_GROUP_EVENT,
           DESELECT_EVENT, DESELECT_ALL_EVENTS, DESTROY_LEAVESLIP, SUBMIT_LEAVESLIP, SUBMIT_GROUPSLIP, DESTROY_GROUPSLIP,
           CHANGE_TRAINEE_VIEW, CHANGE_LEAVESLIP_FORM, CHANGE_GROUPSLIP_FORM, SHOW_CALENDAR, CHANGE_ROLL_FORM, RESET_ROLL_FORM,
           RESET_LEAVESLIP_FORM, RESET_GROUPSLIP_FORM, TOGGLE_LEGEND, TOGGLE_PERIOD_SELECT, EDIT_LEAVESLIP, EDIT_GROUP_LEAVESLIP
           } from '../actions';
-import { SLIP_TYPE_LOOKUP, TA_IS_INFORMED, TA_EMPTY } from '../constants'
+import { SLIP_TYPE_LOOKUP, TA_IS_INFORMED, TA_EMPTY, compareEvents } from '../constants'
 import initialState from '../initialstate'
 import { combineReducers } from 'redux'
 import { addDays } from 'date-fns'
@@ -170,6 +170,8 @@ function selectedEvents(state=[], action) {
       } else {
         return union(state, [action.event], (ev) => ev.id)
       }
+    case TOGGLE_GROUP_EVENT:
+      return action.events
     case DESELECT_ALL_EVENTS:
     case DESTROY_LEAVESLIP:
     case SUBMIT_ROLL:


### PR DESCRIPTION
- [x] Make selected groupevents shaded when viewing in TA detail view
- [x] Select all events between when you click on two noncontiguous groupevents
- [x] Deselect all but clicked event when clicking on a groupevent that is already shaded in a group of three or more shaded contiguous groupevents
- [ ] Update TA detail view form fields for start and end time based on selected groupevents