### PR TITLE
rm empty string ref, allow client to try to hit CDN

### DIFF
--- a/ap/ap/settings/base.py
+++ b/ap/ap/settings/base.py
@@ -418,8 +418,5 @@ PROJECT_HOME = os.path.dirname(SITE_ROOT)
 AUDIO_FILES_ROOT = MEDIA_ROOT + '/audio/Attendance Server'
 AUDIO_FILES_URL = MEDIA_URL + 'audio/Attendance Server'
 
-SELECT2_JS = ''
-SELECT2_CSS = ''
-
 # by default allow rw- r-- r--
 FILE_UPLOAD_PERMISSIONS = 0o644


### PR DESCRIPTION
Pending merging of https://github.com/applegrew/django-select2/pull/484 it'd be nice to not have the errors logged every time people load a page. We can let them try to hit the CDN instead of /static.