### PR TITLE
Changes address requests for room reservation and absentee trainee roster

### DIFF
--- a/ap/absent_trainee_roster/views.py
+++ b/ap/absent_trainee_roster/views.py
@@ -64,7 +64,7 @@ def absent_trainee_form(request):
   bro_unreported = roster.unreported_houses.filter(gender='B')
   sis_unreported = roster.unreported_houses.filter(gender='S')
 
-  if request.user.house in bro_unreported:
+  if request.user.house in bro_unreported | sis_unreported:
     stat = "Unsubmitted"
   else:
     stat = "Submitted"
@@ -73,6 +73,9 @@ def absent_trainee_form(request):
   if time(6) <= datetime.now().time() <= time(8, 05):
     read_only = False
 
+  if datetime.today().weekday() == 6:
+    if time(6) <= datetime.now().time() <= time(8, 25):
+      read_only = False
   c = {
       'formset': formset,
       'user': request.user,

--- a/ap/absent_trainee_roster/views.py
+++ b/ap/absent_trainee_roster/views.py
@@ -74,7 +74,7 @@ def absent_trainee_form(request):
     read_only = False
 
   if datetime.today().weekday() == 6:
-    if time(6) <= datetime.now().time() <= time(8, 25):
+    if time(6) <= datetime.now().time() <= time(8, 20):
       read_only = False
   c = {
       'formset': formset,

--- a/ap/room_reservations/forms.py
+++ b/ap/room_reservations/forms.py
@@ -9,7 +9,7 @@ class RoomReservationForm(forms.ModelForm):
     super(RoomReservationForm, self).__init__(*args, **kwargs)
 
     # These fields are required for clean to be called
-    req_keys = ['group', 'date', 'start', 'end', 'room', 'group_size', 'frequency', 'reason']
+    req_keys = ['group', 'date', 'start', 'end', 'room', 'frequency', 'reason']
     for key in req_keys:
       self.fields[key].required = True
 
@@ -20,4 +20,4 @@ class RoomReservationForm(forms.ModelForm):
 
   class Meta:
     model = RoomReservation
-    fields = ['group', 'date', 'start', 'end', 'room', 'group_size', 'frequency', 'reason']
+    fields = ['group', 'date', 'start', 'end', 'room', 'frequency', 'reason']

--- a/ap/room_reservations/templates/room_reservations/request_list.html
+++ b/ap/room_reservations/templates/room_reservations/request_list.html
@@ -10,7 +10,8 @@
       "ordering": true,
       "info":     false,
       "search":{
-        "search": "Pending"
+        "regex": true,
+        "search": "Pending|Marked"
       },
     });
   });
@@ -34,7 +35,6 @@
           <th>Start</th>
           <th>End</th>
           <th>Room</th>
-          <th>Group Size</th>
           <th>Frequency</th>
           <th>Reason</th>
           <th>Actions</th>
@@ -52,7 +52,6 @@
           <td>{{reservation.start|time}}</td>
           <td>{{reservation.end|time}}</td>
           <td>{{reservation.room}}</td>
-          <td>{{reservation.group_size}}</td>
           <td>{{reservation.frequency}}</td>
           <td>{{reservation.reason}}</td>
           <td>


### PR DESCRIPTION
- Since breakfast is later on Lord's Day, would it be possible to change the time the absent trainee roster is sent to 8:25am?

- The "Group Size" field is not needed for room reservations

- When submitting the daily HC attendance, some HCs are reporting that the system is saying that attendance was already submitted, even though they have not.

- For Room Reservations you have to remove "pending" from the search box and type in "fellowship" or "marked for fellowship". This is too cumbersome and confusing. The list should not be based on a search for "pending