### PR TITLE
fix service checks on review tab, make table fill whole page

### DIFF
--- a/ap/services/templates/services/services_view.html
+++ b/ap/services/templates/services/services_view.html
@@ -369,8 +369,9 @@ Service Scheduling
             {% for category in categories %}
               <th class="category-info">{{ category.name }}</th>
             {% endfor %}
-            {% for c in service_checks %}
-              <th class="service-limits"></th>
+            {% for check in service_checks %}
+              <!-- These are hidden, see datatable columnDefs -->
+              <th class="service-limits">{{ check.name }}</th>
             {% endfor %}
           </tr>
         </thead>
@@ -903,7 +904,7 @@ Service Scheduling
             visible: true
           },
         ],
-        scrollY: '45vh',
+        scrollY: '100%',
         scrollCollapse: true,
         scrollX: true,
         dom: '<"row"<"col-sm-8"Bl><"col-sm-4"f>>' +

--- a/ap/services/utils.py
+++ b/ap/services/utils.py
@@ -408,7 +408,7 @@ class ServiceCheck(object):
     return over_limit
 
 def assignment_day(assignment):
-  return assignment.service.day
+  return assignment.service.weekday
 
 def assignment_cat(assignment):
   cat = assignment.service.category


### PR DESCRIPTION
Fixes these two items from the SS's email to us.
1. fix button on the service portal review tab, (> 1 service/day not working)
2. under the review tab and exception tab can the viewing screen not be constrain in a box. if not open you can make it open in another tab to have it in full screen. 