### PR TITLE
new roll create logic

### DIFF
--- a/ap/attendance/serializers.py
+++ b/ap/attendance/serializers.py
@@ -21,9 +21,9 @@ class RollSerializer(BulkSerializerMixin, ModelSerializer):
     list_serializer_class = BulkListSerializer
     fields = ['id', 'event', 'trainee', 'status', 'finalized', 'notes', 'last_modified', 'submitted_by', 'date']
     validators = [UniqueTogetherValidator(
-        queryset=Roll.objects.all(),
-        fields=('trainee', 'event', 'date', 'submitted_by', 'status'),
-        message='Duplication error for key fields, same status')]
+       queryset=Roll.objects.all(),
+       fields=('trainee', 'event', 'date', 'submitted_by', 'status'),
+       message='Duplication error for key fields, same status')]
 
   def create(self, validated_data):
     trainee = validated_data['trainee']
@@ -31,42 +31,71 @@ class RollSerializer(BulkSerializerMixin, ModelSerializer):
     date = validated_data['date']
     submitted_by = validated_data['submitted_by']
     status = validated_data['status']
+    print validated_data
 
     # checks if roll exists for given trainee, event, and date
     roll_override = Roll.objects.filter(trainee=trainee, event=event.id, date=date)
     leaveslips = IndividualSlip.objects.filter(rolls=roll_override)
+    SELF_ATTENDANCE_ROLL = trainee == submitted_by
 
     if roll_override.count() == 0 and status != 'P':  # if no pre-existing rolls, create
       return Roll.objects.create(**validated_data)
     elif roll_override.count() == 1:  # if a roll already exists,
-      # no changes if there's no status change
-      if status == 'P' and not leaveslips.exists():  # if input roll is "P" and no leave slip, delete it
-        roll_override.delete()
-        return validated_data
+      print 'maybe an audit roll'
       roll = roll_override.first()
 
-      if roll.trainee.self_attendance and (roll.trainee != submitted_by):
-        return validated_data
-      elif roll.trainee.self_attendance and (roll.trainee == submitted_by):
-        roll_override.update(**validated_data)
-        roll_override.update(last_modified=datetime.now())
-        return validated_data
+      # no changes if there's no status change
+      if status == 'P' and not leaveslips.exists():  # if input roll is "P" and no leave slip, delete it
+        if SELF_ATTENDANCE_ROLL:
+          if roll.trainee == submitted_by:
+            roll_override.delete()
+            return validated_data
+          else:
+            return validated_data
+        else:
+          roll_override.delete()
+          return validated_data
+
+      if roll.trainee.self_attendance and not SELF_ATTENDANCE_ROLL:
+        print 'audit roll'
+        if (roll.trainee == roll.submitted_by):
+          return Roll.objects.create(**validated_data)
+          return validated_data
+        else:
+          roll_override.update(**validated_data)
+          roll_override.update(last_modified=datetime.now())
+          return validated_data
+      elif roll.trainee.self_attendance and SELF_ATTENDANCE_ROLL:
+        if (roll.trainee == roll.submitted_by):
+          roll_override.update(**validated_data)
+          roll_override.update(last_modified=datetime.now())
+          return validated_data
+        else:
+          return Roll.objects.create(**validated_data)
+          return validated_data
       elif not roll.trainee.self_attendance:
+        validated_data['submitted_by'] = self.context['request'].user
         roll_override.update(**validated_data)
         return validated_data
       return validated_data
 
     elif roll_override.count() == 2:  # if duplicate rolls
       if trainee.self_attendance:
-        r = roll_override.filter(submitted_by=submitted_by).first()
+        if SELF_ATTENDANCE_ROLL:
+          r = roll_override.filter(submitted_by=submitted_by).first()
+        else:
+          r = roll_override.filter(~Q(submitted_by=trainee)).first()
       else:
+        # THIS SHOULD NEVER HAPPEN
         r = roll_override.filter(~Q(submitted_by=submitted_by)).first()
 
       if r and r.status != status:
-        r.status = status
-        r.submitted_by = self.context['request'].user
-        r.last_modified = datetime.now()
-        r.save()
+        if status == 'P':
+          r.delete()
+        else:
+          r.status = status
+          r.last_modified = datetime.now()
+          r.save()
       return validated_data
     else:
       return validated_data

--- a/ap/attendance/views.py
+++ b/ap/attendance/views.py
@@ -393,6 +393,7 @@ class TableRollsView(GroupRequiredMixin, AttendanceView):
     event_list, trainee_evt_list = Schedule.get_roll_table_by_type_in_weeks(trainees, monitor, [current_week, ], event_type)
 
     rolls = Roll.objects.filter(event__in=event_list, date__gte=start_date, date__lte=end_date).exclude(status='P').select_related('trainee', 'event')
+    print rolls
 
     roll_dict = OrderedDict()
 
@@ -403,6 +404,7 @@ class TableRollsView(GroupRequiredMixin, AttendanceView):
 
     # Add roll to each event from roll table
     for trainee in roll_dict:
+      print trainee
       # Only update if trainee predefined
       if trainee in trainee_evt_list:
         evt_list = trainee_evt_list[trainee]

--- a/libraries/react/scripts/containers/RollPane.js
+++ b/libraries/react/scripts/containers/RollPane.js
@@ -11,12 +11,13 @@ const mapStateToProps = (state) => {
     form: {
       selectedEvents: state.selectedEvents,
       rollStatus: state.form.rollStatus,
-      trainee: state.trainee,
+      trainee: state.form.traineeView,
       trainees: state.trainees,
       traineeView: state.form.traineeView,
     },
     canFinalizeWeek: canFinalizeRolls(state.term, state.date, state.finalizedweeks) ||  isAM(state.trainee),
     canSubmitRoll: canSubmitRoll(dateDetails) ||  isAM(state.trainee),
+    // canSubmitRoll: canFinalizeRolls(state.term, state.date, state.finalizedweeks) || isAM(state.trainee),
   }
 }
 


### PR DESCRIPTION
- Allows AMs to input self-attendance (non-audit) rolls on behalf of the trainee through personal attendance record. (AKA submitted_by == trainee, not the AM)
- More robust roll creation logic