### PR TITLE
Solves Multiple TA Requests. Related to leave slip comment color, TA homepage counts, and Room Reservation Schedule

### DIFF
--- a/ap/aputils/templatetags/smart_cards.py
+++ b/ap/aputils/templatetags/smart_cards.py
@@ -48,19 +48,17 @@ def generate_cards(context):
 
     room_res = RoomReservation.objects.filter(status='P')
     room_reservation_count = room_res.count()
-    room_reservations_ta_count = room_res.filter(requester__in=my_trainees).count()
 
     ann = Announcement.objects.filter(status='P')
     announce_count = ann.count()
-    announce_ta_count = ann.filter(author__in=my_trainees).count()
 
     TA_requests = Card(
         header_title="Requests",
         card_links=[
             CardLink(title="Web Access", url=reverse('web_access:web_access-list'), number=web_access_count, ta_number=web_access_ta_count),
             CardLink(title="AV", url=reverse('audio:ta-audio-home'), number=av_count, ta_number=av_ta_count),
-            CardLink(title="Room Reservation", url=reverse('room_reservations:ta-room-reservation-list'), number=room_reservation_count, ta_number=room_reservations_ta_count),
-            CardLink(title="Announcements", url=reverse('announcements:announcement-request-list'), number=announce_count, ta_number=announce_ta_count)
+            CardLink(title="Room Reservation", url=reverse('room_reservations:ta-room-reservation-list'), number=room_reservation_count),
+            CardLink(title="Announcements", url=reverse('announcements:announcement-request-list'), number=announce_count)
         ]
     )
 

--- a/ap/lifestudies/templates/lifestudies/discipline_list.html
+++ b/ap/lifestudies/templates/lifestudies/discipline_list.html
@@ -115,7 +115,7 @@
                   </a>
                 {% endif %}
               {% empty %}
-              <div class="alert alert-warning"><i>You have not completed any life studies for this discipline.</i></div>
+              <div class="alert alert-comment"><i>You have not completed any life studies for this discipline.</i></div>
               {% endfor %}
               </ul>
             </div>

--- a/ap/room_reservations/templates/room_reservations/schedule_partial.html
+++ b/ap/room_reservations/templates/room_reservations/schedule_partial.html
@@ -26,8 +26,7 @@ $(document).ready(function() {
     "searching": false,
     "ordering": false,
     "scrollY": '60vh',
-    "scrollX": true,
-    "fixedColumns": true
+    "scrollX": true
   });
 
   /* Initialize Datepicker  */

--- a/ap/room_reservations/templates/room_reservations/schedule_partial.html
+++ b/ap/room_reservations/templates/room_reservations/schedule_partial.html
@@ -26,7 +26,8 @@ $(document).ready(function() {
     "searching": false,
     "ordering": false,
     "scrollY": '60vh',
-    "scrollX": true
+    "scrollX": true,
+    "fixedColumns": true
   });
 
   /* Initialize Datepicker  */

--- a/libraries/bootflat-ftta/bootflat/scss/bootflat/_alert.scss
+++ b/libraries/bootflat-ftta/bootflat/scss/bootflat/_alert.scss
@@ -9,8 +9,8 @@ $alert-info:                    $tan-light !default;
 $alert-primary-text:            $blue !default;
 $alert-success-text:            $blue !default;
 $alert-danger-text:             $red !default;
-$alert-warning-text:            $tan !default;
-$alert-info-text:               $tan !default;
+$alert-warning-text:            $black !default;
+$alert-info-text:               $black !default;
 
 $alert-close-color:             $black !default;
 

--- a/libraries/bootflat-ftta/bootflat/scss/bootflat/_alert.scss
+++ b/libraries/bootflat-ftta/bootflat/scss/bootflat/_alert.scss
@@ -5,12 +5,14 @@ $alert-success:                 $blue-light !default;
 $alert-danger:                  $red-light !default;
 $alert-warning:                 $tan-light !default;
 $alert-info:                    $tan-light !default;
+$alert-comment:                 $tan-light !default;
 
 $alert-primary-text:            $blue !default;
 $alert-success-text:            $blue !default;
 $alert-danger-text:             $red !default;
-$alert-warning-text:            $black !default;
-$alert-info-text:               $black !default;
+$alert-warning-text:            $tan !default;
+$alert-info-text:               $tan !default;
+$alert-comment-text:            $black !default;
 
 $alert-close-color:             $black !default;
 
@@ -43,6 +45,11 @@ $alert-link-color:              $grey !default;
           background-color: $alert-warning;
           color: $alert-warning-text;
           border: $alert-warning;
+      }
+      @at-root &-comment {
+          background-color: $alert-comment;
+          color: $alert-comment-text;
+          border: $alert-comment;
       }
       @at-root &-danger {
           background-color: $alert-danger;

--- a/libraries/react/scripts/components/LeaveSlipNote.js
+++ b/libraries/react/scripts/components/LeaveSlipNote.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button, Alert } from 'react-bootstrap'
 
 const LeaveSlipNote = (props) => (
-  <Alert bsStyle="warning" className="dt-leaveslip__note">
+  <Alert bsStyle="comment" className="dt-leaveslip__note">
     <b>Meal sign out:</b> If your leave of absence permits you to miss a meal, <u>you must also</u> sign out on the appropriate meal sign-out sheet.
     <br/>
     <br/>

--- a/libraries/react/scripts/components/TAComments.js
+++ b/libraries/react/scripts/components/TAComments.js
@@ -5,7 +5,7 @@ const TAComments = (props) => {
   return (<div>
     {
       props.comments &&
-      <Alert bsStyle="warning">
+      <Alert bsStyle="comment">
         <b>TA comments:</b> {props.comments}
       </Alert>
     }


### PR DESCRIPTION
This pull request is to solve two bug requests 

- [x]  The color contrast of a TA comment, in addition to the notes on meal sign-outs and service scheduling, on a leave slip as seen by a trainee is poor. @finben

- [x]  On the TA homepage, there are currently two numbers next to "Room Reservations" and "Announcements". As these are not tied to TAs, they can just be shown as one number without any number in parentheses, and in red if there are any pending.
