### PR TITLE
Classnotes fixes

### DIFF
--- a/ap/classnotes/utils.py
+++ b/ap/classnotes/utils.py
@@ -46,7 +46,6 @@ def assign_individual_classnotes(trainee, start, end):
 
   for roll in rolls.iterator():
       classname = roll.event.name
-      number_classnotes = calculate_number_classnotes(trainee, roll)
       leavesliplist = list(get_leaveslip(trainee, roll))
       leavesliplist_length = len(leavesliplist)
       if leavesliplist_length > 0:

--- a/ap/classnotes/utils.py
+++ b/ap/classnotes/utils.py
@@ -14,7 +14,6 @@ def assign_classnotes(week=None):
   start = term.start
   end = term.end
   if week is not None:
-    start = term.startdate_of_week(week)
     end = term.enddate_of_week(week)
   for trainee in Trainee.objects.all().iterator():
     update_classnotes_list(trainee)
@@ -32,8 +31,12 @@ def assign_individual_classnotes(trainee, start, end):
   # look at trainee's absences (for class event).
   # Increment absence_counts based on classname (HStore)
   print trainee
-  regular_absence_counts = {}
+  regular_absence_counts = {} 
   rolls = trainee.rolls.all().filter(date__gte=start, date__lte=end, status='A', event__type='C').order_by('date').select_related('event')
+  if trainee.self_attendance:
+    rolls = rolls.filter(submitted_by=trainee)
+  else:
+    rolls = rolls.exclude(submitted_by=trainee)
   for roll in rolls.iterator():
       classname = roll.event.name
       number_classnotes = calculate_number_classnotes(trainee, roll)

--- a/ap/classnotes/utils.py
+++ b/ap/classnotes/utils.py
@@ -15,7 +15,7 @@ def assign_classnotes(week=None):
   end = term.end
   if week is not None:
     end = term.enddate_of_week(week)
-  for trainee in Trainee.objects.all().filter(firstname="Elizabeth", lastname="Gonzales").iterator():
+  for trainee in Trainee.objects.all().iterator():
     update_classnotes_list(trainee)
     assign_individual_classnotes(trainee, start, end)
 
@@ -60,7 +60,6 @@ def assign_individual_classnotes(trainee, start, end):
               regular_absence_counts[classname] += 1
               if (regular_absence_counts[classname]) > 2:
                 generate_classnotes(trainee, roll, 'R')
-                #regular_absence_counts[classname] -= 1
             else:
               regular_absence_counts[classname] = 1
           # Missed classes with conference or service leave slips results in no class notes
@@ -70,7 +69,6 @@ def assign_individual_classnotes(trainee, start, end):
           regular_absence_counts[classname] += 1
           if (regular_absence_counts[classname]) > 2:
             generate_classnotes(trainee, roll, 'R')
-            #regular_absence_counts[classname] -= 1
         else:
           regular_absence_counts[classname] = 1
 
@@ -102,7 +100,6 @@ def get_leaveslip(trainee, roll):
   roll_start_datetime = datetime.combine(roll.date, roll.event.start)
   roll_end_datetime = datetime.combine(roll.date, roll.event.end)
   groupslips = GroupSlip.objects.filter(trainee=trainee, status='A', start__lte=roll_start_datetime, end__gte=roll_end_datetime)
-  #check for length of query set, if they are both length 0, then return an empty array
   return chain(individualslips, groupslips)
 
 

--- a/ap/classnotes/utils.py
+++ b/ap/classnotes/utils.py
@@ -42,6 +42,7 @@ def assign_individual_classnotes(trainee, start, end):
   rolls = rolls.exclude(event__class_type='AFTN')
   #Monday Revival Meeting
   rolls = rolls.exclude(event__name='Monday Revival Meeting')
+  rolls = rolls.exclude(event__name='Morning Revival Fellowship')
 
   for roll in rolls.iterator():
       classname = roll.event.name

--- a/ap/classnotes/utils.py
+++ b/ap/classnotes/utils.py
@@ -30,25 +30,23 @@ def assign_individual_classnotes(trainee, start, end):
   '''
   # look at trainee's absences (for class event).
   # Increment absence_counts based on classname (HStore)
-  print trainee
-  regular_absence_counts = {} 
+  regular_absence_counts = {}
   rolls = trainee.rolls.all().filter(date__gte=start, date__lte=end, status='A', event__type='C').order_by('date').select_related('event')
   if trainee.self_attendance:
     rolls = rolls.filter(submitted_by=trainee)
   else:
     rolls = rolls.exclude(submitted_by=trainee)
 
-  #Afternoon classes
+  # Afternoon classes
   rolls = rolls.exclude(event__class_type='AFTN')
-  #Monday Revival Meeting
+  # Monday Revival Meeting
   rolls = rolls.exclude(event__name='Monday Revival Meeting')
   rolls = rolls.exclude(event__name='Morning Revival Fellowship')
 
   for roll in rolls.iterator():
       classname = roll.event.name
       leavesliplist = list(get_leaveslip(trainee, roll))
-      leavesliplist_length = len(leavesliplist)
-      if leavesliplist_length > 0:
+      if len(leavesliplist) > 0:
         for leaveslip in leavesliplist:
           # Special: Wedding, Graduation, Funeral, Interview.
           if leaveslip.type in ['INTVW', 'GRAD', 'WED', 'FUNRL']:
@@ -65,7 +63,7 @@ def assign_individual_classnotes(trainee, start, end):
           # Missed classes with conference or service leave slips results in no class notes
       else:
         # no leave slip == unexcused absence
-        if classname in regular_absence_counts:  
+        if classname in regular_absence_counts:
           regular_absence_counts[classname] += 1
           if (regular_absence_counts[classname]) > 2:
             generate_classnotes(trainee, roll, 'R')

--- a/ap/classnotes/views.py
+++ b/ap/classnotes/views.py
@@ -127,7 +127,7 @@ class ClassnotesReportView(ListView):
     classnotes_unsubmitted = classnotes_unsubmitted.order_by('-trainee')
     if week is not None:
       term = Term.current_term()
-      start = term.startdate_of_week(int(week))
+      start = term.start
       end = term.enddate_of_week(int(week))
       classnotes_unsubmitted = classnotes_unsubmitted.filter(date__gte=start, date__lte=end)
       context['for_week'] = str(week)

--- a/ap/lifestudies/views.py
+++ b/ap/lifestudies/views.py
@@ -277,7 +277,7 @@ class AttendanceAssign(ListView):
     context['start_date'] = p.start(period)
     context['end_date'] = p.end(period)
     context['period_list'] = list()
-    for period_num in range(1, 11):
+    for period_num in range(0, 11):
       context['period_list'].append((period_num, p.start(period_num), p.end(period_num)))
     return context
 
@@ -296,7 +296,7 @@ class AttendanceAssign(ListView):
       context['start_date'] = start_date
       context['end_date'] = end_date
       context['period_list'] = list()
-      for period_num in range(1, 11):
+      for period_num in range(0, 11):
         context['period_list'].append((period_num, p.start(period_num), p.end(period_num)))
       context['preview_return'] = 1
       # outstanding_trainees = list()


### PR DESCRIPTION
In order to calculate classnotes properly for regular classnotes(2 freebies before assigning classnotes), needed to look at rolls from the beginning of the term.
Also using self attendance roll if trainee is self attendance
Excluded afternoon classes (PSRP, Greek, Character, German) and MR fellowship, MN revival from classnotes
