### PR TITLE
To add last names to life study table as requested

### DIFF
--- a/ap/lifestudies/templates/lifestudies/discipline_list.html
+++ b/ap/lifestudies/templates/lifestudies/discipline_list.html
@@ -158,7 +158,7 @@
                     <span class="glyphicon glyphicon-pencil"></span>
                   </a>
                 </td>
-                <td>{{discipline.trainee.firstname}} {{discipline.trainee.lastname|slice:"1"}}.</td>
+                <td>{{discipline.trainee.firstname}} {{discipline.trainee.lastname}}</td>
                 <td class="text-danger">{{discipline.infraction}}</td>
                 <td>{{discipline.offense}}</td>
                 <td>{{discipline.quantity}}</td>


### PR DESCRIPTION
- [ ] The module lists trainees only by their first name and last initial. We would like to see the full last name.