### PR TITLE
More exam fixes

### DIFF
--- a/ap/exams/templates/exams/essay_question_template.html
+++ b/ap/exams/templates/exams/essay_question_template.html
@@ -2,8 +2,8 @@
 <li>{{ question.prompt }}</li>
 <b> (Points: {{ question.points }})</b>
 <div class="clearfix"></div>
-<textarea class="form-control exam-response
-  {% if role != 'Take' %}disabled{% endif %}"
+<textarea class="form-control exam-response"
+  {% if role != 'Take' %}disabled{% endif %}
   cols="100" rows="10" placeholder="Type your response here." name="response">{{ response|get_item:forloop.counter }}</textarea>
 <div class="clearfix"></div>
 <b>Word Count: </b><span class="char_count"></span>

--- a/ap/exams/templates/exams/exam.html
+++ b/ap/exams/templates/exams/exam.html
@@ -158,9 +158,15 @@
         }
       });
       if (e.currentTarget.id === "finalize_button") {
-        rtn_data['Submit'] ='true';
+        var confirmed = confirm("Are you sure you want to finalize your exam? You will not be able to edit afterwards.");
+        if (confirmed) {
+          rtn_data['Submit'] ='true';
+        } else {
+          rtn_data['Submit'] ='false';
+          return
+        }
       } else {
-        rtn_data['Submit'] ='false';
+        rtn_data['Submit'] = 'false';
       }
       $.ajax({
         type: 'POST',

--- a/ap/exams/templates/exams/exam_grade.html
+++ b/ap/exams/templates/exams/exam_grade.html
@@ -22,11 +22,13 @@
         <input class="score form-control" id="score-{{forloop.counter}}" type="number" step=".01" name="section-score" value="{{ score|get_item:1 }}">
         <br>
         <b>Comment: </b>
-        <input class="grader-comment form-control" id="comment-{{forloop.counter}}" type="text" name="grader-comment" value="{{ comments|get_item:0 }}">
+        <input class="grader-comment form-control" id="comment-{{forloop.counter}}" type="text" name="grader-comment" value="{{ comments|get_item:1 }}">
         <hr/>
       {% else %}
+        <br>
         <b>Score for {{section.get_section_type_display}} Section: {{ score|get_item:1 }}</b>
-        <b>Comment: {{ comments|get_item:0 }}</b>
+        <br>
+        <b>Comment: {{ comments|get_item:1 }}</b>
       {% endif %}
     {% empty %}
       <i>No exam questions to view.</i><br />

--- a/ap/exams/templates/exams/exam_preview.html
+++ b/ap/exams/templates/exams/exam_preview.html
@@ -28,7 +28,7 @@
           <ol id="question-list">
             {% for section, response, score, comments in data %}
               <b> Instructions: </b> {{ section.instructions|linebreaks }}
-              You must answer at least {{ section.required_number_to_submit }} questions for this section in order to submit the exam.
+              You must answer at least {{ section.required_number_to_submit }} question(s) for this section in order to submit the exam.
               <br>
               {% if section.section_type == 'Matching' %}
                 Matching Options:

--- a/ap/exams/templates/exams/exam_template_list.html
+++ b/ap/exams/templates/exams/exam_template_list.html
@@ -11,10 +11,10 @@ function filterTermClass() {
   $("div.exam-panel").each((i, e) => {
     const elem = $(e);
     elem.show();
-    if (term != "Choose term" && elem.attr('data-term') != term) {
+    if (term != "All Terms" && elem.attr('data-term') != term) {
       elem.hide();
     }
-    if (cls != "Choose class" && elem.attr('data-class') != cls) {
+    if (cls != "All Classes" && elem.attr('data-class') != cls) {
       elem.hide();
     }
   });
@@ -36,23 +36,29 @@ function filterTermClass() {
   </h1>
 
   {% if exam_service %}
-    <select id="term" onchange="filterTermClass()"> Term
-      <option value="Choose term" selected>
-      Choose term
-      </option>
-      {% for term in terms %}
-        <option value="{{ term.name }}">{{ term.name }}</option>
-      {% endfor %}
-    </select>
+    <body onload="filterTermClass()">
+      <select id="term" onchange="filterTermClass()"> Term
+        <option value="All Terms">
+        All Terms
+        </option>
+        {% for term in terms %}
+          {% if forloop.first %}
+          <option value="{{ term.name }}" selected>{{ term.name }}</option>
+          {% else %}
+          <option value="{{ term.name }}">{{ term.name }}</option>
+          {% endif %}
+        {% endfor %}
+      </select>
 
-    <select id="class" onchange="filterTermClass()"> Class
-      <option value="Choose class" selected>
-      Choose class
-      </option>
-      {% for class in classes %}
-        <option value="{{ class.name }}">{{ class.name }}</option>
-      {% endfor %}
-    </select>
+      <select id="class" onchange="filterTermClass()"> Class
+        <option value="All Classes" selected>
+        All Classes
+        </option>
+        {% for class in classes %}
+          <option value="{{ class.name }}">{{ class.name }}</option>
+        {% endfor %}
+      </select>
+    </body>
   {% endif %}
 
   {% for exam in exams %}

--- a/ap/exams/views.py
+++ b/ap/exams/views.py
@@ -151,7 +151,7 @@ class ExamTemplateListView(ListView):
     is_manage = 'manage' in self.kwargs
     ctx['exam_service'] = is_manage and user.is_designated_grader() or is_TA(user)
     ctx['classes'] = Class.regularclasses.all()
-    ctx['terms'] = Term.objects.all()
+    ctx['terms'] = reversed(Term.objects.all())
     return ctx
 
 

--- a/ap/exams/views.py
+++ b/ap/exams/views.py
@@ -100,7 +100,7 @@ class ExamTemplateListView(ListView):
       exams = Exam.objects.all()
     else:
       exams = []
-      if user.type == 'R':
+      if user.type in ['R', 'C']:
         # Open exams
         if user.current_term == 1 or user.current_term == 2:
           for exam in Exam.objects.filter(is_open=True, is_graded_open=False):

--- a/libraries/bootflat-ftta/bootflat/scss/bootflat/_form.scss
+++ b/libraries/bootflat-ftta/bootflat/scss/bootflat/_form.scss
@@ -15,7 +15,7 @@ $message-warning:                  $tan !default;
 $form-font-color:                  $black !default;
 $form-placeholder-font-color:      $brown !default;
 
-$form-disabled-color:              $grey !default;
+$form-disabled-color:              $grey-disabled !default;
 
 $search-query-value:               17px !default;
 

--- a/libraries/bootflat-ftta/bootflat/scss/bootflat/_global.scss
+++ b/libraries/bootflat-ftta/bootflat/scss/bootflat/_global.scss
@@ -18,6 +18,7 @@ $black:                       #102C38 !default;
 $brown:                       #393A42 !default;
 $grey:                        #939598 !default;
 $grey-light:                  #eee;
+$grey-disabled:               #BEBEBE !default;
 $blue-dark:                   #102C38 !default;
 $blue:                        #095F80 !default;
 $blue-light:                  #A6C5D1 !default;


### PR DESCRIPTION
- Preview exam matches current exam for trainees. Shows "question(s)" instead of "question".
- List of exam is filtered by default to current term
- Exam finalization confirmation
- Comments are visible for both the grader and trainee. It used to always show that no comments were available.
- For grading essay questions: the text response area is disabled, and the background color is lighter