### PR TITLE
HC_Names on Survey

### DIFF
--- a/ap/hc/templates/ta/hc_survey_ta_view.html
+++ b/ap/hc/templates/ta/hc_survey_ta_view.html
@@ -90,6 +90,7 @@
         <th>Atmosphere</th>
         <th>Situations</th>
         <th>Comment</th>
+        <th>HC</th>
       </tr>
     </thead>
     <tbody>
@@ -97,6 +98,7 @@
         <td>{{snc.survey.atmosphere}}</td>
         <td>{{snc.survey.situations}}</td>
         <td>{{snc.survey.comment}}</td>
+        <td>{{snc.survey.hc}}</td>
       </tr>
     </tbody>
   </table>

--- a/ap/hc/templates/ta/hc_survey_ta_view.html
+++ b/ap/hc/templates/ta/hc_survey_ta_view.html
@@ -90,7 +90,7 @@
         <th>Atmosphere</th>
         <th>Situations</th>
         <th>Comment</th>
-        <th>HC</th>
+        <th>HCs</th>
       </tr>
     </thead>
     <tbody>
@@ -98,7 +98,7 @@
         <td>{{snc.survey.atmosphere}}</td>
         <td>{{snc.survey.situations}}</td>
         <td>{{snc.survey.comment}}</td>
-        <td>{{snc.survey.hc}}</td>
+        <td>{{snc.survey.house.get_hcs}}</td>
       </tr>
     </tbody>
   </table>

--- a/ap/houses/models.py
+++ b/ap/houses/models.py
@@ -54,6 +54,9 @@ class House(models.Model):
   def residents_list(self):
     return sorted_user_list_str(self.residents.filter(is_active=True))
 
+  def get_hcs(self):
+    return sorted_user_list_str(self.residents.filter(groups__name="HC"))
+
   #returns a query set of the empty bunks for this house
   def empty_bunk_count(self,position_list=[]):
     if len(position_list)==0:

--- a/ap/lifestudies/templates/lifestudies/discipline_detail.html
+++ b/ap/lifestudies/templates/lifestudies/discipline_detail.html
@@ -20,6 +20,7 @@
           <span class="glyphicon glyphicon-plus-sign"></span> Decrease Penalty
         </button>
       </form>
+      <br>Note: {{discipline.note}}</br>
     </div>
   </div>
   <p>

--- a/ap/lifestudies/templates/lifestudies/discipline_list.html
+++ b/ap/lifestudies/templates/lifestudies/discipline_list.html
@@ -147,6 +147,7 @@
               <th> Due Date </th>
               <th> Unapproved</th>
               <th> Approved</th>
+              <th> Note</th>
             </tr>
           </thead>
           <tbody>
@@ -187,6 +188,7 @@
                     {% endif %}
                   {% endfor %}
                 </td>
+                <td> {{discipline.note}}</td>
               </tr>
 
           {% endfor %}


### PR DESCRIPTION
- [x] Add names of house coordinator to the HC survey reports.
- [x] Once a Life-study summary is assigned, there is no way to view the notes that were inputted (e.g., to note what service was missed, the time of mobile phone offense, etc.).
- [x]  List view - want to see notes they entered. 