### PR TITLE
To allow sort by denied

### DIFF
--- a/ap/aputils/templatetags/smart_menu.py
+++ b/ap/aputils/templatetags/smart_menu.py
@@ -106,7 +106,8 @@ def generate_menu(context):
       common=[
           SubMenuItem(name='Bible Reading Tracker', url='bible_tracker:index'),
           SubMenuItem(name='Class Files', url='classes:index'),
-          SubMenuItem(name='Greek Vocab', url='http://attendance.ftta.lan/ftta/greek/greekVocab.php')
+          SubMenuItem(name='Greek Vocab', url='http://attendance.ftta.lan/ftta/greek/greekVocab.php'),
+          SubMenuItem(name='TC Printer Instructions', url='http://attendance.ftta.lan/ftta/printers.php')
       ],
       ta_only=[
           SubMenuItem(name='Daily Announcements', url='announcements:announcement-list'),

--- a/ap/leaveslips/views.py
+++ b/ap/leaveslips/views.py
@@ -213,7 +213,7 @@ class TALeaveSlipList(GroupRequiredMixin, generic.TemplateView):
     ctx['TA_list'] = TrainingAssistant.objects.filter(groups__name='regular_training_assistant')
     ctx['leaveslips'] = slips
     ctx['selected_ta'] = ta
-    ctx['status_list'] = LeaveSlip.LS_STATUS[:-1]  # Removes Sister Approved Choice
+    ctx['status_list'] = LeaveSlip.LS_STATUS  # Removes Sister Approved Choice
     ctx['selected_status'] = status
     ctx['selected_trainee'] = tr
     ctx['trainee_list'] = Trainee.objects.all()


### PR DESCRIPTION
This is a one liner that I think may solve the issue of them not being able to filter/sort by denied for TA leaveslips. I think this issue came about when we took TA sister marked for fellowship off as a status and we never changed this line of code. If it looks good to you lets merge in.