### PR TITLE
To have non-popups show up on read list

### DIFF
--- a/ap/announcements/views.py
+++ b/ap/announcements/views.py
@@ -109,6 +109,8 @@ class AnnouncementsRead(generic.ListView):
   def get_queryset(self):
     trainee = self.request.user
     announcements = Announcement.objects.filter(trainees_read=trainee)
+    announcements |= Announcement.objects.filter(is_popup=False, trainees_show=trainee)
+    announcements |= Announcement.objects.filter(type='SERVE', is_popup=False, all_trainees=True)
     return announcements
 
 


### PR DESCRIPTION
- [ ] TAs are able to submit server announcements, but trainees are not receiving them. (BF Announcements that are not pop up announcements are not showing up under announcement read list but only under the notification bell)