### PR TITLE
Pre-term designated hours force page

### DIFF
--- a/ap/services/utils.py
+++ b/ap/services/utils.py
@@ -443,6 +443,8 @@ def unfinalized_service(user):
   # return list of service_id and week
   if has_designated_service(user):
     current_term = Term.current_term()
+    if date.today() < current_term.start:
+      return None
     # current week = up to week we want to access + 1
     current_week = Term.reverse_date(current_term, datetime.date.today())[0]
     worker = trainee_from_user(user).worker


### PR DESCRIPTION
Added condition to not check for whether to redirect to the designated service hours force page if the current date is before the start of the term. We ran into this issue during import Spring 2019. The logic for unfinalized_service is not well defined when the current date is before the start of the term, which will happen before every term once we do the import.