### PR TITLE
link main class events to seating chart

### DIFF
--- a/ap/schedules/management/commands/update_charts.py
+++ b/ap/schedules/management/commands/update_charts.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+from schedules.models import Event
+from seating.models import Chart
+
+
+class Command(BaseCommand):
+
+  # to use: python ap/manage.py update_charts --settings=ap.settings.dev
+  def _update_charts(self):
+  	main_classes = Event.objects.filter(class_type='MAIN')
+  	main_chart = Chart.objects.get(name="Main")
+  	for main_class in main_classes:
+  		main_class.chart = main_chart
+  		main_class.save()
+
+  def handle(self, *args, **options):
+    print("* Updating charts...")
+    self._update_charts()  	

--- a/ap/schedules/management/commands/update_charts.py
+++ b/ap/schedules/management/commands/update_charts.py
@@ -15,4 +15,4 @@ class Command(BaseCommand):
 
   def handle(self, *args, **options):
     print("* Updating charts...")
-    self._update_charts()  	
+    self._update_charts()


### PR DESCRIPTION
Currently, main class events aren't linked to any seating chart. The issue of linking new seating charts to events still needs to be fixed; this is a quick fix for now so attendance monitors can save a lot of time. #1599 