### PR TITLE
Leaveslips: redirect TAs to TA view

### DIFF
--- a/ap/attendance/templates/attendance/_attendance_data.html
+++ b/ap/attendance/templates/attendance/_attendance_data.html
@@ -25,6 +25,7 @@
   var Term = {{ term_bb|safe }};
   var FinalizedWeeks = {{ finalize_bb|safe }};
   var AM_GROUPS = {{ am_groups|safe }};
+  var TA_GROUP = {{ ta_group|safe }};
   var CSRF_TOKEN = getCookie('csrftoken');
   {% if show %}
     var Show = '{{show}}';

--- a/ap/attendance/views.py
+++ b/ap/attendance/views.py
@@ -138,7 +138,11 @@ def react_attendance_context(trainee, request_params=None):
   finalize_bb = listJSONRenderer.render(RollsFinalizationSerializer(finalize_obj).data)
 
   am_groups = Group.objects.filter(name__in=['attendance_monitors', 'training_assistant'])
+  ta_group = Group.objects.filter(name='training_assistant')
+
   groups = [g['id'] for g in am_groups.values('id')]
+  ta_ids = [g['id'] for g in ta_group.values('id')]
+
   ctx = {
       'events_bb': events_bb,
       'groupevents_bb': groupevents_bb,
@@ -153,6 +157,7 @@ def react_attendance_context(trainee, request_params=None):
       'disablePeriodSelect': disablePeriodSelect,
       'finalize_bb': finalize_bb,
       'am_groups': json.dumps(groups),
+      'ta_group': json.dumps(ta_ids),
   }
   return ctx
 

--- a/libraries/react/scripts/components/Summary.js
+++ b/libraries/react/scripts/components/Summary.js
@@ -4,6 +4,7 @@ import { Alert, Button } from 'react-bootstrap'
 import SlipDetail from './SlipDetail'
 import { FA_ICON_LOOKUP } from '../constants'
 
+
 const Summary = (p) => {
   let eventsWithRolls = p.eventsRolls.filter(esr => esr.event.roll)
   let unexcused_absences = eventsWithRolls.filter(esr => esr.event.roll.status === 'A' && esr.event.status.slip !== 'approved')
@@ -43,7 +44,7 @@ const Summary = (p) => {
           <div className="col-xs-1">Submitted</div>
         </div>
         {p.leaveslips.sort((s1, s2) => s1.submitted > s2.submitted ? -1 : 1)
-          .map((slip, i) => <SlipDetail slip={slip} key={i} onClick={() => p.editSlip(slip)} deleteSlip={p.deleteSlip} /> )}
+          .map((slip, i) => <SlipDetail slip={slip} key={i} onClick={() => p.isTA ? window.open("/leaveslips/individual/update/" + slip.id) : p.editSlip(slip)} deleteSlip={p.deleteSlip} /> )}
         </div> : ''
       }
 
@@ -57,7 +58,7 @@ const Summary = (p) => {
           <div className="col-xs-1">Submitted</div>
         </div>
         {p.groupslips.sort((s1, s2) => s1.submitted > s2.submitted ? -1 :1)
-          .map((slip, i) => <SlipDetail trainee={p.trainee} slip={slip} key={i} onClick={() => p.editGroupSlip(slip)} deleteSlip={p.deleteGroupSlip} /> )}
+          .map((slip, i) => <SlipDetail trainee={p.trainee} slip={slip} key={i} onClick={() => p.isTA ? window.open("/leaveslips/group/update/" + slip.id) : p.editGroupSlip(slip)} deleteSlip={p.deleteGroupSlip} /> )}
         </div> : ''
       }
 

--- a/libraries/react/scripts/components/Summary.js
+++ b/libraries/react/scripts/components/Summary.js
@@ -4,7 +4,6 @@ import { Alert, Button } from 'react-bootstrap'
 import SlipDetail from './SlipDetail'
 import { FA_ICON_LOOKUP } from '../constants'
 
-
 const Summary = (p) => {
   let eventsWithRolls = p.eventsRolls.filter(esr => esr.event.roll)
   let unexcused_absences = eventsWithRolls.filter(esr => esr.event.roll.status === 'A' && esr.event.status.slip !== 'approved')

--- a/libraries/react/scripts/constants.js
+++ b/libraries/react/scripts/constants.js
@@ -234,3 +234,12 @@ export const isAM = (user) => {
   }
   return false;
 }
+
+export const isTA = (user) => {
+  for (let group of TA_GROUP) {
+    if (user.groups.indexOf(group) >= 0) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/libraries/react/scripts/containers/SummaryPane.js
+++ b/libraries/react/scripts/containers/SummaryPane.js
@@ -2,12 +2,14 @@ import { connect } from 'react-redux'
 import { deleteLeaveSlip, editLeaveSlip, editGroupLeaveSlip, deleteGroupSlip } from '../actions'
 import { getGroupSlipsforPeriod, getLeaveSlipsforPeriod, getEventsByRollStatus } from '../selectors/selectors'
 import Summary from '../components/Summary'
+import { isTA } from '../constants'
 
 const mapStateToProps = (state) => {
   return {
     eventsRolls: getEventsByRollStatus(state),
     groupslips: getGroupSlipsforPeriod(state),
     leaveslips: getLeaveSlipsforPeriod(state),
+    isTA: isTA(state.trainee),
   }
 }
 


### PR DESCRIPTION
When a TA clicks on a leaveslip in the summary pane, the TA detailed view of the leaveslip will open in a new window.