### PR TITLE
Put in logic for counting group leave slips.

### DIFF
--- a/ap/aputils/templatetags/panels.py
+++ b/ap/aputils/templatetags/panels.py
@@ -7,7 +7,7 @@ from classnotes.models import Classnotes
 from django import template
 from django.core.urlresolvers import reverse
 from django.db.models import Q
-from leaveslips.models import IndividualSlip
+from leaveslips.models import IndividualSlip, GroupSlip
 from lifestudies.models import Discipline
 from terms.models import Term
 
@@ -78,8 +78,9 @@ def generate_panels(context):
   )
 
   ls_pending = 0
-  ls_p = IndividualSlip.objects.filter(trainee=user, status='P')
-  ls_pending = sum([1 if p in slip.periods else 0 for slip in ls_p])
+  ls_ip = IndividualSlip.objects.filter(trainee=user, status='P')
+  ls_gp = GroupSlip.objects.filter(trainees=user, status='P')
+  ls_pending = sum([1 if p in slip.periods else 0 for slip in ls_ip] + [1 if p in slip.periods else 0 for slip in ls_gp])
 
   leaveslips_panel = Panel(
       name='Leave Slips Pending',


### PR DESCRIPTION
- [ ] When switching to an account of a trainee with pending leave slips, I noticed that the number of the homepage reads zero for pending leave slips. Joanna's note: The homepage count is not counting pending group slips. It does count personal slips, as far as I can tell


I just added some logic to account for group leave slips which wasn't being done before. Super simple. Thanks Ryan.