### PR TITLE
1597 formatting

### DIFF
--- a/libraries/bootflat-ftta/bootflat/scss/bootflat/_alert.scss
+++ b/libraries/bootflat-ftta/bootflat/scss/bootflat/_alert.scss
@@ -6,6 +6,7 @@ $alert-danger:                  $red-light !default;
 $alert-warning:                 $tan-light !default;
 $alert-info:                    $tan-light !default;
 $alert-comment:                 $tan-light !default;
+$alert-TAComment:               #E85328 !default;
 
 $alert-primary-text:            $blue !default;
 $alert-success-text:            $blue !default;
@@ -13,6 +14,8 @@ $alert-danger-text:             $red !default;
 $alert-warning-text:            $tan !default;
 $alert-info-text:               $tan !default;
 $alert-comment-text:            $black !default;
+$alert-TAComment-text:          $white !default;
+
 
 $alert-close-color:             $black !default;
 
@@ -50,6 +53,11 @@ $alert-link-color:              $grey !default;
           background-color: $alert-comment;
           color: $alert-comment-text;
           border: $alert-comment;
+      }
+      @at-root &-TAComment {
+          background-color: $alert-TAComment;
+          color: $alert-TAComment-text;
+          border: $alert-TAComment;
       }
       @at-root &-danger {
           background-color: $alert-danger;

--- a/libraries/bootflat-ftta/bootflat/scss/bootflat/_alert.scss
+++ b/libraries/bootflat-ftta/bootflat/scss/bootflat/_alert.scss
@@ -6,7 +6,7 @@ $alert-danger:                  $red-light !default;
 $alert-warning:                 $tan-light !default;
 $alert-info:                    $tan-light !default;
 $alert-comment:                 $tan-light !default;
-$alert-TAComment:               #E85328 !default;
+$alert-notice:                  $red-light !default;
 
 $alert-primary-text:            $blue !default;
 $alert-success-text:            $blue !default;
@@ -14,7 +14,7 @@ $alert-danger-text:             $red !default;
 $alert-warning-text:            $tan !default;
 $alert-info-text:               $tan !default;
 $alert-comment-text:            $black !default;
-$alert-TAComment-text:          $white !default;
+$alert-notice-text:             $white !default;
 
 
 $alert-close-color:             $black !default;
@@ -54,10 +54,10 @@ $alert-link-color:              $grey !default;
           color: $alert-comment-text;
           border: $alert-comment;
       }
-      @at-root &-TAComment {
-          background-color: $alert-TAComment;
-          color: $alert-TAComment-text;
-          border: $alert-TAComment;
+      @at-root &-notice {
+          background-color: $alert-notice;
+          color: $alert-notice-text;
+          border: $alert-notice;
       }
       @at-root &-danger {
           background-color: $alert-danger;

--- a/libraries/react/scripts/components/Summary.js
+++ b/libraries/react/scripts/components/Summary.js
@@ -61,7 +61,7 @@ const Summary = (p) => {
         </div> : ''
       }
 
-      <Alert bsStyle="danger" className="dt-leaveslip__note">
+      <Alert bsStyle="notice" className="dt-leaveslip__note">
         Note: Report information will not be up-to-date until attendance office hours (i.e., when the potential violators list is posted).
       </Alert>
     </div>

--- a/libraries/react/scripts/components/TAComments.js
+++ b/libraries/react/scripts/components/TAComments.js
@@ -5,7 +5,7 @@ const TAComments = (props) => {
   return (<div>
     {
       props.comments &&
-      <Alert bsStyle="info">
+      <Alert bsStyle="TAComment">
         <b>TA comments:</b> {props.comments}
       </Alert>
     }

--- a/libraries/react/scripts/components/TAComments.js
+++ b/libraries/react/scripts/components/TAComments.js
@@ -5,7 +5,7 @@ const TAComments = (props) => {
   return (<div>
     {
       props.comments &&
-      <Alert bsStyle="TAComment">
+      <Alert bsStyle="notice">
         <b>TA comments:</b> {props.comments}
       </Alert>
     }


### PR DESCRIPTION
- [x] Leave slip TA comments show in blue boxes inside the detailed view (trainee side). Let's make this box red/orange instead of blue.

Changed the colors to make it more consistent.

Original:
![image](https://user-images.githubusercontent.com/12653261/56855742-66144900-6901-11e9-8213-fdf2c974b9da.png)

New:
![image](https://user-images.githubusercontent.com/12653261/56855737-4bda6b00-6901-11e9-995d-5463a1cdc2c1.png)


Also, as per Isaac, we changed the notice underneath the leaveslips for consistency.

Original:
![image](https://user-images.githubusercontent.com/12653261/56855751-8b08bc00-6901-11e9-9dd0-e91b6f2d4a14.png)
New:
![image](https://user-images.githubusercontent.com/12653261/56855753-9a880500-6901-11e9-933e-6d41a3afae10.png)
