### PR TITLE
Newly added trainees for designated services

### DIFF
--- a/ap/services/forms.py
+++ b/ap/services/forms.py
@@ -13,7 +13,7 @@ from services.models import (Assignment, Category, Qualification,
                              ServiceAttendance, ServiceException, ServiceRoll,
                              Worker, WorkerGroup)
 from terms.models import Term
-from datetime import date, datetime, timedelta
+from datetime import date
 
 # This is written to improve query performance on admin backend
 class WorkerPrejoinMixin(forms.ModelForm):

--- a/ap/services/forms.py
+++ b/ap/services/forms.py
@@ -12,6 +12,8 @@ from services.models import (Assignment, Category, Qualification,
                              SeasonalServiceSchedule, Service,
                              ServiceAttendance, ServiceException, ServiceRoll,
                              Worker, WorkerGroup)
+from terms.models import Term
+from datetime import date, datetime, timedelta
 
 # This is written to improve query performance on admin backend
 class WorkerPrejoinMixin(forms.ModelForm):
@@ -195,6 +197,17 @@ class ServiceForm(forms.Form):
 
     for group in groups_cleaned:
       group.user_set.add(*list(Trainee.objects.filter(worker__in=workers_cleaned)))
+
+    # populating the designated hours for newly added trainees so that the force page doesn't show.
+    current_term = Term.current_term()
+    week_range = range(0, current_term.term_week_of_date(date.today()))
+    for worker in workers_cleaned:
+      services = worker.designated.all()
+      for service in services:
+        for week in week_range:
+          service_attendance = ServiceAttendance.objects.get_or_create(designated_service=service, worker=worker, term=current_term, week=week)[0]
+          service_attendance.excused = True
+          service_attendance.save()
 
   def __init__(self, *args, **kwargs):
     super(ServiceForm, self).__init__(*args, **kwargs)


### PR DESCRIPTION
- [ ] Trainees newly added to designated services are required to input hours from previous weeks they were not on the service. Is there a way to forego this? If not, then please fix the bug not allowing them to input zero hours.

Used the logic from the script that Carlos wrote and implemented it afterwards adding new trainees in.