### PR TITLE
TA room reservation optimization

### DIFF
--- a/ap/room_reservations/views.py
+++ b/ap/room_reservations/views.py
@@ -108,7 +108,7 @@ class TARoomReservationList(GroupRequiredMixin, TemplateView):
 
   def get_context_data(self, **kwargs):
     ctx = super(TARoomReservationList, self).get_context_data(**kwargs)
-    reservations = RoomReservation.objects.all()
+    reservations = RoomReservation.objects.all().select_related("requester").select_related("room")
     ctx['reservations'] = reservations
     return ctx
 

--- a/ap/room_reservations/views.py
+++ b/ap/room_reservations/views.py
@@ -108,6 +108,9 @@ class TARoomReservationList(GroupRequiredMixin, TemplateView):
 
   def get_context_data(self, **kwargs):
     ctx = super(TARoomReservationList, self).get_context_data(**kwargs)
+    # Leaving the query call to be just "RoomReservations.objects.all()" does thousands of the same query call
+    # causing it to be extremely slow. select_related uses foreign-keys relationships of "requester" and "room" 
+    # that don't require databause queries significantly improving performance to be within usable load times for the user.
     reservations = RoomReservation.objects.all().select_related("requester").select_related("room")
     ctx['reservations'] = reservations
     return ctx

--- a/ap/room_reservations/views.py
+++ b/ap/room_reservations/views.py
@@ -110,7 +110,7 @@ class TARoomReservationList(GroupRequiredMixin, TemplateView):
     ctx = super(TARoomReservationList, self).get_context_data(**kwargs)
     # Leaving the query call to be just "RoomReservations.objects.all()" does thousands of the same query call
     # causing it to be extremely slow. select_related uses foreign-keys relationships of "requester" and "room" 
-    # that don't require databause queries significantly improving performance to be within usable load times for the user.
+    # that don't require database queries significantly improving performance to be within usable load times for the user.
     reservations = RoomReservation.objects.all().select_related("requester").select_related("room")
     ctx['reservations'] = reservations
     return ctx


### PR DESCRIPTION
The TA view page for room reservations was doing many duplicate SQL calls, making the page load way, way too slow. Removed the duplicate SQL calls.

To test:
just go to room reservations as TA and see if the load times are much faster