### PR TITLE
Badges fix for printing badges

### DIFF
--- a/ap/badges/views.py
+++ b/ap/badges/views.py
@@ -91,7 +91,6 @@ def pictureRange(begin, end):
   return pictureRangeArray
 
 
-@group_required(['training_assistant', 'badges'])
 def printSelectedChoicesOnly(Badge, request, context):
   print 'ids to print', request.POST.getlist('choice')
   copies = int(request.POST.get('copies', 1))


### PR DESCRIPTION
Removing permissions above printSelectedChoicesOnly because it was breaking the page allowing the badges team to print out badges.