### PR TITLE
Removed a permissions line on the Badge Module in views.py

### DIFF
--- a/ap/badges/views.py
+++ b/ap/badges/views.py
@@ -251,7 +251,6 @@ class BadgePrintGeneralBackView(BadgesGroupRequiredMixin, ListView):
     return context
 
 
-@group_required(['training_assistant', 'badges'])
 def facebookOrder(queryset):
   return queryset.order_by('lastname', 'firstname')
 


### PR DESCRIPTION
This line is breaking my access to print the Facebook, even when signed in as a TA. Same fix as the one Michael commited 2 days ago #1732 

@Plew approved because:
"Looks good, Michael said this should be a good fix because users shouldnt be able to access the page to send this post request in the first place."

Same thing here.