### PR TITLE
TA Sisters unable to transfer group leave slips

### DIFF
--- a/ap/leaveslips/templates/leaveslips/_ta_actions.html
+++ b/ap/leaveslips/templates/leaveslips/_ta_actions.html
@@ -5,15 +5,11 @@
   <button type="button" data-transfer-ta="{{leaveslip.trainee.TA_secondary.id}}" data-ls-action="transfer" data-ls-type="{{leaveslip.classname}}" data-ls-id="{{leaveslip.id}}" class="ls-action btn-lg btn-primary btn-save" id="transfer-ls">Transfer</button>
 </div>
 {% else %}
-<!-- I'm commenting out this block of code. David Tien originally wrote it and he's not sure why it was needed
-without using a time machine because a TA sister should never get brother's leave slip. In the event that it does (like it has been), we should probably not allow the TA sister to accept or deny - rather only let them transfer it. That being said, it means there's another bug causing brother group leave slips to be assigned to TA sisters. We'll leave this block of code to allow TA sisters to transfer in case this does happen. -->
-<!--   <button type="button" data-ls-action="approve" data-ls-type="{{leaveslip.classname}}" data-ls-id="{{leaveslip.id}}" title="Approve" class="ls-action btn-lg btn-success" id="approve-ls">
-    <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
-  </button>
-  <button type="button" data-ls-action="deny" data-ls-type="{{leaveslip.classname}}" data-ls-id="{{leaveslip.id}}" title="Deny" class="ls-action btn-lg btn-danger" id="deny-ls">
-    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-  </button> -->
-  <button type="button" data-transfer-ta="{{leaveslip.trainee.TA_secondary.id}}" data-ls-action="transfer" data-ls-type="{{leaveslip.classname}}" data-ls-id="{{leaveslip.id}}" class="ls-action btn-lg btn-primary btn-save" id="transfer-ls">Transfer</button>
+<!--
+  This is for an edge case where a trainee brother would submit a groupleave slip, but then a sister would then edit it before it gets approved. It doesn't happen too often, but what happens is that the slip gets transferred to the TA sister of the sister who re-submitted it. As per Jerome, transfer it back to the original TA brother. 
+
+  data-transfer-ta="{{leaveslip.trainee.TA.id}}" instead of "TA_secondary" because the original submitter would have been a brother and they don't have a secondary TA -->
+  <button type="button" data-transfer-ta="{{leaveslip.trainee.TA.id}}" data-ls-action="transfer" data-ls-type="{{leaveslip.classname}}" data-ls-id="{{leaveslip.id}}" class="ls-action btn-lg btn-primary btn-save" id="transfer-ls">Transfer</button>
 
 {% endif %}
 

--- a/ap/leaveslips/templates/leaveslips/_ta_actions.html
+++ b/ap/leaveslips/templates/leaveslips/_ta_actions.html
@@ -8,7 +8,8 @@
 <!--
   This is for an edge case where a trainee brother would submit a groupleave slip, but then a sister would then edit it before it gets approved. It doesn't happen too often, but what happens is that the slip gets transferred to the TA sister of the sister who re-submitted it. As per Jerome, transfer it back to the original TA brother. 
 
-  data-transfer-ta="{{leaveslip.trainee.TA.id}}" instead of "TA_secondary" because the original submitter would have been a brother and they don't have a secondary TA -->
+  In the code, it is changed to {{leaveslip.trainee.TA.id}} instead of "{{leaveslip.trainee.TA_secondary.id}}" because the original submitter would have been a brother and they don't have a secondary TA 
+-->
   <button type="button" data-transfer-ta="{{leaveslip.trainee.TA.id}}" data-ls-action="transfer" data-ls-type="{{leaveslip.classname}}" data-ls-id="{{leaveslip.id}}" class="ls-action btn-lg btn-primary btn-save" id="transfer-ls">Transfer</button>
 
 {% endif %}

--- a/ap/leaveslips/templates/leaveslips/_ta_actions.html
+++ b/ap/leaveslips/templates/leaveslips/_ta_actions.html
@@ -5,12 +5,16 @@
   <button type="button" data-transfer-ta="{{leaveslip.trainee.TA_secondary.id}}" data-ls-action="transfer" data-ls-type="{{leaveslip.classname}}" data-ls-id="{{leaveslip.id}}" class="ls-action btn-lg btn-primary btn-save" id="transfer-ls">Transfer</button>
 </div>
 {% else %}
-  <button type="button" data-ls-action="approve" data-ls-type="{{leaveslip.classname}}" data-ls-id="{{leaveslip.id}}" title="Approve" class="ls-action btn-lg btn-success" id="approve-ls">
+<!-- I'm commenting out this block of code. David Tien originally wrote it and he's not sure why it was needed
+without using a time machine because a TA sister should never get brother's leave slip. In the event that it does (like it has been), we should probably not allow the TA sister to accept or deny - rather only let them transfer it. That being said, it means there's another bug causing brother group leave slips to be assigned to TA sisters. We'll leave this block of code to allow TA sisters to transfer in case this does happen. -->
+<!--   <button type="button" data-ls-action="approve" data-ls-type="{{leaveslip.classname}}" data-ls-id="{{leaveslip.id}}" title="Approve" class="ls-action btn-lg btn-success" id="approve-ls">
     <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
   </button>
   <button type="button" data-ls-action="deny" data-ls-type="{{leaveslip.classname}}" data-ls-id="{{leaveslip.id}}" title="Deny" class="ls-action btn-lg btn-danger" id="deny-ls">
     <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-  </button>
+  </button> -->
+  <button type="button" data-transfer-ta="{{leaveslip.trainee.TA_secondary.id}}" data-ls-action="transfer" data-ls-type="{{leaveslip.classname}}" data-ls-id="{{leaveslip.id}}" class="ls-action btn-lg btn-primary btn-save" id="transfer-ls">Transfer</button>
+
 {% endif %}
 
 {% if leaveslip.status != 'F'%}

--- a/ap/leaveslips/templates/leaveslips/_ta_actions_js.html
+++ b/ap/leaveslips/templates/leaveslips/_ta_actions_js.html
@@ -41,7 +41,7 @@ $(document).ready(() => {
       slipData += statusData;
     }
 
-    var ignore = ["fellowship", "unfellowship", "sister-save"];
+    var ignore = ["fellowship", "unfellowship"];
     if (ignore.indexOf(action) !== -1 || ($("#id_TA").length && !$("#id_TA").val())) {
       var i = slipData.indexOf("TA=");
       if (i !== -1) {

--- a/ap/leaveslips/templates/leaveslips/_ta_actions_js.html
+++ b/ap/leaveslips/templates/leaveslips/_ta_actions_js.html
@@ -41,7 +41,7 @@ $(document).ready(() => {
       slipData += statusData;
     }
 
-    var ignore = ["fellowship", "unfellowship"];
+    var ignore = ["fellowship", "unfellowship", "sister-save"];
     if (ignore.indexOf(action) !== -1 || ($("#id_TA").length && !$("#id_TA").val())) {
       var i = slipData.indexOf("TA=");
       if (i !== -1) {


### PR DESCRIPTION
Removed a parameter, "sister-save", that ignores when a sister TA would save something which is how they would be able to choose a person to transfer it to. I think without any prior commenting, it's hard to say why it was there in the first place - it might be a safety precaution but either way I don't foresee it being an issue.

EDIT:
Actually we talked to David about this and he's wondering why it would ever get assigned to a brother leaveslip would ever get assigned to a sister TA. Probably fix that bug. The fact that TA sisters only have the option to accept or deny probably is a side-problem... I'll just add a "transfer" button in the event that it happens.

EDIT again:
I replicated the behavior of a TA sister getting a group leave slip that a brother submitted. When a group leave slip is not processed yet, if a trainee sister on the group leave slip changes anything, then it gets transferred over to the trainee sister's TA sister. That being said, I think since it's not a common problem it's pretty low priority. TA sisters can just transfer it back to a TA brother now.


To test:
Check if TA sisters assigned group leave slips from trainee brothers are able to transfer it another TA.

e.g. leaveslips/group/update/29337
