### PR TITLE
International Locality Fix. Grad Remembrance Report Update.

### DIFF
--- a/ap/graduation/templates/graduation/rem_report.html
+++ b/ap/graduation/templates/graduation/rem_report.html
@@ -75,6 +75,7 @@
       <tr>
         <th>Firstname</th>
         <th>Lastname</th>
+        <th>Locality</th>
         <th>Remembrance Text</th>
         <th>Remembrance Reference</th>
       </tr>
@@ -84,6 +85,7 @@
       <tr id="{{m.id}}">
         <td>{{m.trainee.firstname}}</td>
         <td>{{m.trainee.lastname}}</td>
+        <td>{{m.trainee.locality}}</td>
         <td class="rem-text">{{m.remembrance_text}}</td>
         <td class="rem-ref">{{m.remembrance_reference}}</td>
       </tr>

--- a/ap/localities/models.py
+++ b/ap/localities/models.py
@@ -1,6 +1,5 @@
 from django.db import models
 
-from django_countries.fields import CountryField
 from django_countries import countries
 
 from aputils.models import City
@@ -28,7 +27,7 @@ class Locality(models.Model):
       else:
         city_str = city_str + ", " + str(dict(countries)[self.city.country])
       return city_str
-      #Changed the unicode function to match that of City. 
+      #Changed the unicode function to match that of City.
       #Properly returns city,country for international localities.
       #return self.city.name + ", " + str(self.city.state)
     except AttributeError as e:

--- a/ap/localities/models.py
+++ b/ap/localities/models.py
@@ -23,13 +23,13 @@ class Locality(models.Model):
   def __unicode__(self):
     try:
       city_str = self.city.name
-
       if self.city.country == 'US':
         city_str = city_str + ", " + str(self.city.state)
       else:
         city_str = city_str + ", " + str(dict(countries)[self.city.country])
       return city_str
-      #return str(self.city)
+      #Changed the unicode function to match that of City. 
+      #Properly returns city,country for international localities.
       #return self.city.name + ", " + str(self.city.state)
     except AttributeError as e:
       return str(self.id) + ": " + str(e)

--- a/ap/localities/models.py
+++ b/ap/localities/models.py
@@ -1,5 +1,8 @@
 from django.db import models
 
+from django_countries.fields import CountryField
+from django_countries import countries
+
 from aputils.models import City
 
 """ LOCALITIES models.py
@@ -19,7 +22,15 @@ class Locality(models.Model):
 
   def __unicode__(self):
     try:
-      return self.city.name + ", " + str(self.city.state)
+      city_str = self.city.name
+
+      if self.city.country == 'US':
+        city_str = city_str + ", " + str(self.city.state)
+      else:
+        city_str = city_str + ", " + str(dict(countries)[self.city.country])
+      return city_str
+      #return str(self.city)
+      #return self.city.name + ", " + str(self.city.state)
     except AttributeError as e:
       return str(self.id) + ": " + str(e)
 


### PR DESCRIPTION
Localities for foreign trainees were showing up as city, NONE. Changed the Locality unicode function to match that of City. Hopefully this does not break everything else that uses the Locality model. Also added a Locality column to the grad remembrance report.