### PR TITLE
Enable read-only option on gospel trip admin page

### DIFF
--- a/ap/gospel_trips/forms.py
+++ b/ap/gospel_trips/forms.py
@@ -131,7 +131,7 @@ class AnswerForm(forms.ModelForm):
           pass
 
       if self.instance.question.section.show == 'READ ONLY':
-        self.fields['response'].widget.attrs['readonly'] = 'true'
+        self.fields['response'].widget.attrs['disabled'] = 'true'
 
       self.fields['response'].required = req
 


### PR DESCRIPTION
Fixed the "read-only" bug mentioned in #1548