### PR TITLE
Service scheduling workers getting the same services

### DIFF
--- a/ap/services/service_scheduler.py
+++ b/ap/services/service_scheduler.py
@@ -82,17 +82,24 @@ class ServiceScheduler(object):
     cost = []
     t = timeit_inline("Creating cost")
     t.start()
-    for i, w in enumerate(workers):
-      sick_level = calculate_worker_value(w, sick_level_func, sum)
+
+    for i, worker in enumerate(workers):
+      sick_level = calculate_worker_value(worker, sick_level_func, sum)
       freqs = calculate_worker_value(
-          w,
+          worker,
           lambda w: w.weighted_service_frequency,
           lambda s: sum(s, Counter())
       )
 
       c = []
       for service, slot in tasks:
-        c.append(freqs.get(service.category, 0) +
+
+        # frequency_value is an indicator of how often worker has done a particular service, specific to the weekday.
+        frequency_value = 0
+        if freqs.get(service.category):
+          frequency_value = freqs.get(service.category).get(service.weekday, 0)
+
+        c.append(frequency_value +
                  sick_level / 10 -
                  slot.worker_group.assign_priority)
       cost.append(c)

--- a/ap/services/service_scheduler.py
+++ b/ap/services/service_scheduler.py
@@ -79,10 +79,10 @@ class ServiceScheduler(object):
 
     def sick_level_func(w):
       return float(max(10 - w.health, 1))
+
     cost = []
     t = timeit_inline("Creating cost")
     t.start()
-
     for i, worker in enumerate(workers):
       sick_level = calculate_worker_value(worker, sick_level_func, sum)
       freqs = calculate_worker_value(
@@ -93,12 +93,10 @@ class ServiceScheduler(object):
 
       c = []
       for service, slot in tasks:
-
         # frequency_value is an indicator of how often worker has done a particular service, specific to the weekday.
         frequency_value = 0
         if freqs.get(service.category):
           frequency_value = freqs.get(service.category).get(service.weekday, 0)
-
         c.append(frequency_value +
                  sick_level / 10 -
                  slot.worker_group.assign_priority)


### PR DESCRIPTION
tweaks service scheduling algorithm to be more specific. includes not just service category frequency but also the day of the week the service happens. tested by making sure Devon no longer gets the same assignments each week. Fixes #1787